### PR TITLE
refactor(tob): 拆分 1041 行首页、排序数据化、加 reduced-motion

### DIFF
--- a/src/components/BloggerCard.vue
+++ b/src/components/BloggerCard.vue
@@ -1,0 +1,161 @@
+<script setup>
+defineProps({
+  blogger: { type: Object, required: true },
+  expanded: { type: Boolean, default: false },
+  isKol: { type: Boolean, default: false },
+  isKoc: { type: Boolean, default: false },
+  hasOnlyOnePlatform: { type: Boolean, default: false },
+  fallbackAvatar: { type: String, required: true }
+})
+
+const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 'avatar-error'])
+</script>
+
+<template>
+  <div class="group bg-white rounded-2xl shadow-md hover:shadow-lg transition-all duration-300 border border-gray-100 flex flex-col h-full">
+    <div class="relative p-5 xl:p-4 flex flex-col flex-1">
+      <span
+        v-if="isKol"
+        class="absolute -top-3 -right-3 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-white/95 border border-amber-300/70 text-amber-600 text-xs font-semibold shadow-sm"
+      >
+        <span class="text-base leading-none">✨</span>
+        <span class="pr-1">KOL</span>
+      </span>
+      <span
+        v-else-if="isKoc"
+        class="absolute -top-3 -right-3 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-white/95 border border-sky-300/80 text-sky-600 text-xs font-semibold shadow-sm"
+      >
+        <span class="text-base leading-none">🌟</span>
+        <span class="pr-1">KOC</span>
+      </span>
+
+      <div class="mb-4">
+        <div class="flex justify-center">
+          <img
+            :src="blogger.avatar"
+            :alt="blogger.name"
+            :data-fallback-avatar="fallbackAvatar"
+            @error="emit('avatar-error', $event)"
+            class="w-14 h-14 rounded-full object-cover border border-indigo-100 group-hover:border-indigo-300 transition-colors"
+          />
+        </div>
+
+        <div class="mt-3 min-w-0">
+          <div class="w-full text-center">
+            <span class="relative inline-block max-w-full">
+              <span class="text-lg font-semibold text-gray-900 whitespace-normal break-words leading-snug group-hover:text-indigo-600 transition-colors">
+                {{ blogger.name }}
+              </span>
+              <span class="absolute left-full ml-2 top-1/2 -translate-y-1/2 text-sm font-medium text-indigo-600 whitespace-nowrap">
+                {{ blogger.followers }}
+              </span>
+            </span>
+          </div>
+          <p class="text-xs text-gray-500 mt-1 leading-snug line-clamp-3">{{ blogger.introduction }}</p>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap gap-1.5 mt-4">
+        <template v-for="account in blogger.socialAccounts" :key="account.platform">
+          <a
+            v-if="account && account.url && account.url.trim() !== ''"
+            :href="account.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-gray-700 whitespace-nowrap hover:bg-indigo-100 hover:text-indigo-700 transition-colors cursor-pointer"
+            @click="emit('link-click', { platform: account.platform, url: account.url, bloggerName: blogger.name })"
+          >
+            <span class="mr-1">{{ account.icon }}</span>
+            {{ account.platform }}
+          </a>
+          <span
+            v-else
+            class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-gray-500 whitespace-nowrap opacity-60"
+          >
+            <span class="mr-1">{{ account.icon }}</span>
+            {{ account.platform }}
+          </span>
+        </template>
+
+        <button
+          v-if="hasOnlyOnePlatform"
+          type="button"
+          class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-indigo-600 whitespace-nowrap hover:bg-indigo-100 hover:text-indigo-700 transition-colors cursor-pointer"
+          @click.stop="emit('request-platforms', blogger)"
+        >
+          平台补全中
+        </button>
+      </div>
+
+      <button
+        @click="emit('toggle-expanded', blogger.id)"
+        class="mt-4 w-full py-2 px-4 bg-indigo-50 hover:bg-indigo-100 text-indigo-700 rounded-lg transition-colors flex items-center justify-center group-hover:bg-indigo-600 group-hover:text-white"
+      >
+        <span>{{ expanded ? '收起详情' : '查看更多' }}</span>
+        <svg
+          class="ml-2 w-4 h-4 transform transition-transform"
+          :class="{ 'rotate-180': expanded }"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+    </div>
+
+    <transition
+      enter-active-class="transition-all duration-300 ease-out"
+      enter-from-class="opacity-0 max-h-0"
+      enter-to-class="opacity-100 max-h-96"
+      leave-active-class="transition-all duration-300 ease-in"
+      leave-from-class="opacity-100 max-h-96"
+      leave-to-class="opacity-0 max-h-0"
+    >
+      <div v-show="expanded" class="px-5 xl:px-4 pb-5 border-t border-gray-100 bg-gray-50/60 rounded-b-2xl">
+        <div class="pt-4 space-y-3 text-sm">
+          <div>
+            <h4 class="font-semibold text-gray-900 mb-1">专长领域</h4>
+            <div class="flex flex-wrap gap-1.5">
+              <span
+                v-for="specialty in blogger.expandedContent.specialties"
+                :key="specialty"
+                class="px-2.5 py-0.5 bg-blue-100 text-blue-700 rounded-full"
+              >
+                {{ specialty }}
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <h4 class="font-semibold text-gray-900 mb-1">成就荣誉</h4>
+            <ul class="space-y-1">
+              <li
+                v-for="achievement in blogger.expandedContent.achievements"
+                :key="achievement"
+                class="text-gray-600 flex items-center"
+              >
+                <span class="text-green-500 mr-1.5">✓</span>
+                {{ achievement }}
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h4 class="font-semibold text-gray-900 mb-1">最近文章</h4>
+            <ul class="space-y-1">
+              <li
+                v-for="post in blogger.expandedContent.recentPosts"
+                :key="post"
+                class="text-gray-600 flex items-center"
+              >
+                <span class="text-indigo-500 mr-1.5">📝</span>
+                {{ post }}
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>

--- a/src/components/BloggerControls.vue
+++ b/src/components/BloggerControls.vue
@@ -1,0 +1,109 @@
+<script setup>
+defineProps({
+  viewMode: { type: String, required: true },
+  selectedPlatform: { type: String, required: true },
+  sortField: { type: String, required: true },
+  sortOrder: { type: String, required: true },
+  availablePlatforms: { type: Array, required: true },
+  rosterFile: { type: String, required: true }
+})
+
+const emit = defineEmits([
+  'update:viewMode',
+  'update:selectedPlatform',
+  'update:sortField',
+  'update:sortOrder',
+  'copy-table'
+])
+
+const onSortFieldChange = (e) => {
+  emit('update:sortField', e.target.value)
+  emit('update:sortOrder', 'desc')
+}
+
+const toggleOrder = (current) => emit('update:sortOrder', current === 'asc' ? 'desc' : 'asc')
+</script>
+
+<template>
+  <div class="mb-8 flex flex-col md:flex-row justify-between items-center gap-4 bg-white p-4 rounded-xl shadow-sm border border-gray-100">
+    <div class="flex flex-wrap items-center gap-4 w-full md:w-auto">
+      <div class="flex items-center gap-2">
+        <span class="text-sm text-gray-500 whitespace-nowrap">筛选平台:</span>
+        <select
+          :value="selectedPlatform"
+          @change="emit('update:selectedPlatform', $event.target.value)"
+          class="block w-40 pl-3 pr-10 h-10 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md border"
+        >
+          <option value="all">全部平台</option>
+          <option v-for="platform in availablePlatforms" :key="platform" :value="platform">
+            {{ platform }}
+          </option>
+        </select>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <span class="text-sm text-gray-500 whitespace-nowrap">排序:</span>
+        <select
+          :value="sortField"
+          @change="onSortFieldChange"
+          class="block w-40 md:w-44 pl-3 pr-10 h-10 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md border"
+        >
+          <option value="cooperationHeat">合作热度</option>
+          <option value="recommended">合作推荐</option>
+          <option value="followers">粉丝数</option>
+        </select>
+        <button
+          v-if="!['cooperationHeat', 'recommended'].includes(sortField)"
+          @click="toggleOrder(sortOrder)"
+          class="flex items-center justify-center w-10 h-10 text-gray-500 hover:text-indigo-600 border border-gray-300 rounded-md transition-colors bg-white shadow-sm"
+          title="切换升序/降序"
+        >
+          <span class="text-lg leading-none">{{ sortOrder === 'asc' ? '⬆️' : '⬇️' }}</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-3 w-full md:w-auto justify-between md:justify-end">
+      <div class="flex bg-gray-100 p-1 rounded-lg shrink-0">
+        <a
+          :href="rosterFile"
+          download="博主联盟花名册v20260106.xlsx"
+          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1 bg-white text-indigo-600 shadow-sm hover:text-indigo-700"
+          title="下载博主联盟花名册到本地"
+        >
+          <span>⬇️</span>
+          <span class="hidden sm:inline">下载到本地</span>
+        </a>
+
+        <button
+          v-if="viewMode === 'table'"
+          @click="emit('copy-table')"
+          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1 text-gray-500 hover:text-green-700"
+          title="复制当前表格数据到剪贴板，可直接粘贴到Excel"
+        >
+          <span>📋</span>
+          <span class="hidden sm:inline">复制表格数据</span>
+        </button>
+      </div>
+
+      <div class="flex bg-gray-100 p-1 rounded-lg shrink-0">
+        <button
+          @click="emit('update:viewMode', 'grid')"
+          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1"
+          :class="viewMode === 'grid' ? 'bg-white text-indigo-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
+        >
+          <span>📷</span>
+          <span class="hidden sm:inline">卡片</span>
+        </button>
+        <button
+          @click="emit('update:viewMode', 'table')"
+          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1"
+          :class="viewMode === 'table' ? 'bg-white text-indigo-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
+        >
+          <span>📋</span>
+          <span class="hidden sm:inline">表格</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/BloggerTable.vue
+++ b/src/components/BloggerTable.vue
@@ -1,0 +1,126 @@
+<script setup>
+defineProps({
+  bloggers: { type: Array, required: true },
+  availablePlatforms: { type: Array, required: true },
+  fallbackAvatarFor: { type: Function, required: true },
+  hasOnlyOnePlatform: { type: Function, required: true },
+  getAccountByPlatform: { type: Function, required: true }
+})
+
+const emit = defineEmits(['link-click', 'request-platforms', 'avatar-error'])
+</script>
+
+<template>
+  <div class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200 table-fixed">
+        <thead class="bg-gray-50">
+          <tr>
+            <th
+              scope="col"
+              class="w-56 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider select-none sticky left-0 bg-gray-50 z-10 shadow-[2px_0_5px_rgba(0,0,0,0.05)]"
+            >
+              博主信息
+            </th>
+            <th scope="col" class="w-40 px-6 py-3 text-left text-xs font-bold uppercase tracking-wider select-none text-gray-400">
+              粉丝基数
+            </th>
+            <th scope="col" class="w-80 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider">擅长领域</th>
+            <th scope="col" class="w-96 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider hidden md:table-cell">
+              个人简介
+            </th>
+            <th
+              v-for="platform in availablePlatforms"
+              :key="platform"
+              scope="col"
+              class="w-64 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider border-l border-gray-100"
+            >
+              {{ platform }}
+            </th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <tr v-for="blogger in bloggers" :key="blogger.id" class="hover:bg-gray-50 transition-colors">
+            <td class="px-6 py-4 whitespace-nowrap sticky left-0 bg-white group-hover:bg-gray-50 z-10 shadow-[2px_0_5px_rgba(0,0,0,0.05)]">
+              <div class="flex items-center">
+                <div class="flex-shrink-0 h-10 w-10">
+                  <img
+                    class="h-10 w-10 rounded-full border border-gray-200 object-cover"
+                    :src="blogger.avatar"
+                    :alt="blogger.name"
+                    :data-fallback-avatar="fallbackAvatarFor(blogger.name)"
+                    @error="emit('avatar-error', $event)"
+                  />
+                </div>
+                <div class="ml-4">
+                  <div class="text-sm font-medium text-gray-900">
+                    <span>{{ blogger.name }}</span>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap">
+              <span class="text-sm font-bold text-indigo-600">{{ blogger.followers }}</span>
+            </td>
+            <td class="px-6 py-4">
+              <div class="flex flex-wrap gap-1">
+                <span
+                  v-for="(specialty, idx) in blogger.expandedContent.specialties.slice(0, 3)"
+                  :key="idx"
+                  class="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-50 text-blue-700"
+                >
+                  {{ specialty }}
+                </span>
+                <span v-if="blogger.expandedContent.specialties.length > 3" class="text-xs text-gray-400">...</span>
+              </div>
+            </td>
+            <td class="px-6 py-4 hidden md:table-cell">
+              <div class="text-sm text-gray-500 line-clamp-2 max-w-xs" :title="blogger.introduction">
+                {{ blogger.introduction }}
+              </div>
+            </td>
+            <td v-for="platform in availablePlatforms" :key="platform" class="px-6 py-4 whitespace-nowrap">
+              <template v-if="getAccountByPlatform(blogger, platform)">
+                <div class="flex items-center gap-1.5">
+                  <span class="text-lg">{{ getAccountByPlatform(blogger, platform).icon }}</span>
+                  <a
+                    :href="getAccountByPlatform(blogger, platform).url"
+                    target="_blank"
+                    class="text-sm text-indigo-400 hover:text-indigo-600 underline truncate max-w-[120px] transition-colors"
+                    :title="getAccountByPlatform(blogger, platform).url"
+                    @click="emit('link-click', {
+                      platform: getAccountByPlatform(blogger, platform).platform,
+                      url: getAccountByPlatform(blogger, platform).url,
+                      bloggerName: blogger.name
+                    })"
+                  >
+                    {{
+                      getAccountByPlatform(blogger, platform).platform.includes(':')
+                        ? getAccountByPlatform(blogger, platform).platform.split(':')[1]
+                        : '点击查看'
+                    }}
+                  </a>
+
+                  <button
+                    v-if="hasOnlyOnePlatform(blogger)"
+                    type="button"
+                    class="text-xs text-indigo-500 hover:text-indigo-700 underline ml-1"
+                    @click.stop="emit('request-platforms', blogger)"
+                  >
+                    平台补全中
+                  </button>
+                </div>
+              </template>
+              <span v-else class="text-gray-300 text-xs">-</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div v-if="bloggers.length === 0" class="p-8 text-center text-gray-500">没有找到匹配的博主，请尝试其他关键词。</div>
+    </div>
+    <div class="bg-gray-50 px-6 py-3 border-t border-gray-200 text-xs text-center text-gray-500">
+      提示：您可以直接复制表格内容，并粘贴到 Excel、Notion 或飞书中。
+    </div>
+  </div>
+</template>

--- a/src/components/BrandMarquee.vue
+++ b/src/components/BrandMarquee.vue
@@ -1,0 +1,21 @@
+<script setup>
+import { partnerBrands } from '../data/bloggerInfo.js'
+</script>
+
+<template>
+  <div class="relative overflow-hidden">
+    <div class="flex animate-scroll">
+      <div class="flex space-x-12 whitespace-nowrap">
+        <!-- 渲染两组用于无缝循环 -->
+        <div v-for="copy in 2" :key="copy" class="flex items-center space-x-8">
+          <div v-for="brand in partnerBrands" :key="`${copy}-${brand.name}`" class="flex flex-col items-center">
+            <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
+              <img :src="brand.img" :alt="brand.name" class="w-12 h-12 object-contain" />
+            </div>
+            <span class="text-sm text-gray-600">{{ brand.name }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/QrCorner.vue
+++ b/src/components/QrCorner.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { ref } from 'vue'
+import qrcodeImage from '../img/qrcode1.jpg'
+
+const hidden = ref(false)
+const collapsed = ref(false)
+</script>
+
+<template>
+  <div v-if="!hidden" class="fixed bottom-6 right-6 z-50">
+    <div class="relative animate-float">
+      <div class="absolute inset-0 bg-gradient-to-br from-blue-400/20 to-purple-400/20 rounded-2xl blur-xl"></div>
+
+      <div class="relative bg-white/95 backdrop-blur-md rounded-2xl shadow-xl border border-white/50 p-2 w-52 hover:shadow-2xl hover:scale-105 transition-all duration-300">
+        <div class="mb-1">
+          <div class="relative">
+            <div class="h-6 flex items-center justify-center text-sm font-bold text-gray-800">合作与共创</div>
+            <div class="absolute right-0 top-0 h-6 flex items-center gap-1">
+              <button
+                type="button"
+                class="inline-flex items-center justify-center w-6 h-6 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                :title="collapsed ? '展开' : '收缩'"
+                @click.stop="collapsed = !collapsed"
+              >
+                <span class="text-base leading-none">{{ collapsed ? '+' : '−' }}</span>
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center w-6 h-6 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                title="关闭"
+                @click.stop="hidden = true"
+              >
+                <span class="text-base leading-none">×</span>
+              </button>
+            </div>
+          </div>
+          <div v-if="!collapsed" class="text-center text-xs text-gray-500">扫码/添加微信号atar24</div>
+        </div>
+
+        <div v-if="!collapsed" class="bg-gray-50 p-1 rounded-xl">
+          <img
+            :src="qrcodeImage"
+            alt="微信二维码"
+            class="w-full h-auto rounded-lg object-contain"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-10px); }
+}
+.animate-float {
+  animation: float 3s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-float {
+    animation: none;
+  }
+}
+</style>

--- a/src/data/bloggerInfo.js
+++ b/src/data/bloggerInfo.js
@@ -661,6 +661,34 @@ export const bloggersData = [
   }
 ]
 
+// 合作热度排序优先级（按列表顺序：越靠前越高）
+// 匹配规则：博主姓名包含此关键词即视为命中
+// 调整这里即可重排首页"合作热度"排序，无需改动页面代码
+export const cooperationHeatOrder = [
+  '安东尼',
+  '主任',
+  '前端之虎',
+  '小包',
+  '中杯可乐',
+  '阿杆',
+  '浪里行舟',
+  'ErpanOmer',
+  '南方者',
+  '万少'
+]
+
+// 首页 hero 区域的合作品牌数据
+export const partnerBrands = [
+  { name: '亚马逊科技', img: '/src/img/brand/aws.png' },
+  { name: '百度文心大模型', img: '/src/img/brand/baidu.png' },
+  { name: '字节火山引擎', img: '/src/img/brand/bytedance.png' },
+  { name: 'Finclip小程序', img: '/src/img/brand/finclip.png' },
+  { name: '明基显示器', img: '/src/img/brand/benq.png' },
+  { name: '秦托邦社区', img: '/src/img/brand/qintopia.png' },
+  { name: 'PaddleOCR', img: '/src/img/brand/paddleocr.png' },
+  { name: '秒哒', img: '/src/img/brand/miao.png' }
+]
+
 // 产品工具数据
 export const toolsData = [
   {

--- a/src/pages/tob/index.vue
+++ b/src/pages/tob/index.vue
@@ -33,14 +33,10 @@
               </router-link>
             </span>
           </p>
-          
 
-          <!-- 统计信息 -->
           <div class="grid grid-cols-1 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
             <div class="text-center">
-              <div class="text-3xl font-bold text-indigo-600 mb-2">
-                {{ bloggerStats.bloggerCount }} 位+
-              </div>
+              <div class="text-3xl font-bold text-indigo-600 mb-2">{{ bloggerStats.bloggerCount }} 位+</div>
               <div class="text-gray-600">技术博主</div>
             </div>
             <div class="text-center">
@@ -56,10 +52,7 @@
               <div class="text-gray-600">辐射社群</div>
             </div>
           </div>
-          
 
-          
-          <!-- 合作品牌轮播 -->
           <div class="mt-12 max-w-4xl mx-auto">
             <div class="mb-6 flex items-center justify-center">
               <div class="flex flex-wrap items-center justify-center gap-3">
@@ -78,134 +71,22 @@
                   <span class="text-base leading-none">🔥</span>
                   <span>我要合作</span>
                   <span class="text-base leading-none transition-transform group-hover:translate-x-1">→</span>
-                  <span
-                    class="pointer-events-none absolute right-0 top-0 -translate-y-[calc(100%+10px)] whitespace-nowrap rounded-lg bg-gray-900 px-2.5 py-1.5 text-xs text-white opacity-0 shadow-lg transition-opacity duration-200 group-hover:opacity-100"
-                  >
+                  <span class="pointer-events-none absolute right-0 top-0 -translate-y-[calc(100%+10px)] whitespace-nowrap rounded-lg bg-gray-900 px-2.5 py-1.5 text-xs text-white opacity-0 shadow-lg transition-opacity duration-200 group-hover:opacity-100">
                     进入服务介绍
                   </span>
                 </router-link>
               </div>
             </div>
             <h3 class="mb-4 text-center text-sm md:text-base font-semibold text-gray-600">已合作品牌</h3>
-            <div class="relative overflow-hidden">
-              <div class="flex animate-scroll">
-                <div class="flex space-x-12 whitespace-nowrap">
-                  <!-- 第一组品牌 -->
-                  <div class="flex items-center space-x-8">
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/aws.png" alt="亚马逊科技" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">亚马逊科技</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/baidu.png" alt="百度文心大模型" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">百度文心大模型</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/bytedance.png" alt="字节火山引擎" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">字节火山引擎</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/finclip.png" alt="Finclip小程序" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">Finclip小程序</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/benq.png" alt="明基显示器" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">明基显示器</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/qintopia.png" alt="秦托邦社区" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">秦托邦社区</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/paddleocr.png" alt="PaddleOCR" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">PaddleOCR</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/miao.png" alt="秒哒" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">秒哒</span>
-                    </div>
-                  </div>
-                  <!-- 第二组品牌（重复，用于无缝轮播） -->
-                  <div class="flex items-center space-x-8">
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/aws.png" alt="亚马逊科技" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">亚马逊科技</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/baidu.png" alt="百度文心大模型" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">百度文心大模型</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/bytedance.png" alt="字节火山引擎" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">字节火山引擎</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/finclip.png" alt="Finclip小程序" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">Finclip小程序</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/benq.png" alt="明基显示器" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">明基显示器</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/qintopia.png" alt="秦托邦社区" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">秦托邦社区</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/paddleocr.png" alt="PaddleOCR" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">PaddleOCR</span>
-                    </div>
-                    <div class="flex flex-col items-center">
-                      <div class="w-16 h-16 bg-white rounded-lg flex items-center justify-center mb-2 shadow-sm border border-gray-200">
-                        <img src="/src/img/brand/miao.png" alt="秒哒" class="w-12 h-12 object-contain">
-                      </div>
-                      <span class="text-sm text-gray-600">秒哒</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <BrandMarquee />
           </div>
         </div>
       </div>
-      
-      <!-- 装饰性背景元素 -->
+
       <div class="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
         <div class="absolute top-20 left-10 w-20 h-20 bg-indigo-200 rounded-full opacity-20 animate-pulse"></div>
         <div class="absolute top-40 right-20 w-16 h-16 bg-purple-200 rounded-full opacity-20 animate-pulse delay-1000"></div>
         <div class="absolute bottom-20 left-20 w-12 h-12 bg-blue-200 rounded-full opacity-20 animate-pulse delay-2000"></div>
-        
-
       </div>
     </section>
 
@@ -222,373 +103,47 @@
         </p>
       </div>
 
-      <!-- 控制栏：筛选与视图切换 -->
-      <div class="mb-8 flex flex-col md:flex-row justify-between items-center gap-4 bg-white p-4 rounded-xl shadow-sm border border-gray-100">
-        <!-- 左侧：筛选器 -->
-        <div class="flex flex-wrap items-center gap-4 w-full md:w-auto">
-          <!-- 平台筛选 -->
-          <div class="flex items-center gap-2">
-            <span class="text-sm text-gray-500 whitespace-nowrap">筛选平台:</span>
-            <select
-              v-model="selectedPlatform"
-              class="block w-40 pl-3 pr-10 h-10 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md border"
-            >
-              <option value="all">全部平台</option>
-              <option v-for="platform in availablePlatforms" :key="platform" :value="platform">
-                {{ platform }}
-              </option>
-            </select>
-          </div>
+      <BloggerControls
+        v-model:viewMode="viewMode"
+        v-model:selectedPlatform="selectedPlatform"
+        v-model:sortField="sortField"
+        v-model:sortOrder="sortOrder"
+        :available-platforms="availablePlatforms"
+        :roster-file="bloggerRosterFile"
+        @copy-table="copyTableToClipboard"
+      />
 
-          <!-- 排序筛选 (统一交互) -->
-          <div class="flex items-center gap-2">
-            <span class="text-sm text-gray-500 whitespace-nowrap">排序:</span>
-            <select
-              v-model="sortField"
-              @change="sortOrder = 'desc'"
-              class="block w-40 md:w-44 pl-3 pr-10 h-10 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md border"
-            >
-              <option value="cooperationHeat">合作热度</option>
-              <option value="recommended">合作推荐</option>
-              <option value="followers">粉丝数</option>
-            </select>
-            <button
-              @click="sortOrder = sortOrder === 'asc' ? 'desc' : 'asc'"
-              class="flex items-center justify-center w-10 h-10 text-gray-500 hover:text-indigo-600 border border-gray-300 rounded-md transition-colors bg-white shadow-sm"
-              title="切换升序/降序"
-              v-if="!['cooperationHeat', 'recommended'].includes(sortField)"
-            >
-              <span class="text-lg leading-none">{{ sortOrder === "asc" ? "⬆️" : "⬇️" }}</span>
-            </button>
-          </div>
-        </div>
-
-        <!-- 右侧：全局操作 -->
-        <div class="flex items-center gap-3 w-full md:w-auto justify-between md:justify-end">
-          <!-- 操作按钮组 -->
-          <div class="flex bg-gray-100 p-1 rounded-lg shrink-0">
-            <a
-              :href="bloggerRosterFile"
-              download="博主联盟花名册v20260106.xlsx"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1 bg-white text-indigo-600 shadow-sm hover:text-indigo-700"
-              title="下载博主联盟花名册到本地"
-            >
-              <span>⬇️</span>
-              <span class="hidden sm:inline">下载到本地</span>
-            </a>
-
-            <!-- 导出/复制按钮 (仅在表格模式下显示) -->
-            <button
-              v-if="viewMode === 'table'"
-              @click="copyTableToClipboard"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1 text-gray-500 hover:text-green-700"
-              title="复制当前表格数据到剪贴板，可直接粘贴到Excel"
-            >
-              <span>📋</span>
-              <span class="hidden sm:inline">复制表格数据</span>
-            </button>
-          </div>
-
-          <!-- 视图切换按钮 -->
-          <div class="flex bg-gray-100 p-1 rounded-lg shrink-0">
-            <button
-              @click="viewMode = 'grid'"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1"
-              :class="viewMode === 'grid' ? 'bg-white text-indigo-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
-            >
-              <span>📷</span>
-              <span class="hidden sm:inline">卡片</span>
-            </button>
-            <button
-              @click="viewMode = 'table'"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1"
-              :class="viewMode === 'table' ? 'bg-white text-indigo-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
-            >
-              <span>📋</span>
-              <span class="hidden sm:inline">表格</span>
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <!-- 视图内容 -->
-
-      <!-- 1. 卡片视图 (Grid View) -->
       <div v-if="viewMode === 'grid'" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6">
-        <div
+        <BloggerCard
           v-for="blogger in filteredAndSortedBloggers"
           :key="blogger.id"
-          class="group bg-white rounded-2xl shadow-md hover:shadow-lg transition-all duration-300 border border-gray-100 flex flex-col h-full"
-        >
-          <!-- 博主基本信息 -->
-          <div class="relative p-5 xl:p-4 flex flex-col flex-1">
-            <span
-              v-if="isKOL(blogger.followers)"
-              class="absolute -top-3 -right-3 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-white/95 border border-amber-300/70 text-amber-600 text-xs font-semibold shadow-sm"
-            >
-              <span class="text-base leading-none">✨</span>
-              <span class="pr-1">KOL</span>
-            </span>
-            <span
-              v-else-if="isKOC(blogger.followers)"
-              class="absolute -top-3 -right-3 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-white/95 border border-sky-300/80 text-sky-600 text-xs font-semibold shadow-sm"
-            >
-              <span class="text-base leading-none">🌟</span>
-              <span class="pr-1">KOC</span>
-            </span>
-            <div class="mb-4">
-              <div class="flex justify-center">
-                <img
-                  :src="blogger.avatar"
-                  :alt="blogger.name"
-                  :data-fallback-avatar="getFallbackAvatar(blogger.name)"
-                  @error="handleAvatarError"
-                  class="w-14 h-14 rounded-full object-cover border border-indigo-100 group-hover:border-indigo-300 transition-colors"
-                />
-              </div>
-
-              <div class="mt-3 min-w-0">
-                <div class="w-full text-center">
-                  <span class="relative inline-block max-w-full">
-                    <span class="text-lg font-semibold text-gray-900 whitespace-normal break-words leading-snug group-hover:text-indigo-600 transition-colors">
-                      {{ blogger.name }}
-                    </span>
-                    <span class="absolute left-full ml-2 top-1/2 -translate-y-1/2 text-sm font-medium text-indigo-600 whitespace-nowrap">
-                      {{ blogger.followers }}
-                    </span>
-                  </span>
-                </div>
-                <p class="text-xs text-gray-500 mt-1 leading-snug line-clamp-3">{{ blogger.introduction }}</p>
-              </div>
-            </div>
-
-            <!-- 社交账号 -->
-            <div class="flex flex-wrap gap-1.5 mt-4">
-              <template v-for="account in blogger.socialAccounts" :key="account.platform">
-                <a
-                  v-if="account && account.url && account.url.trim() !== ''"
-                  :href="account.url"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-gray-700 whitespace-nowrap hover:bg-indigo-100 hover:text-indigo-700 transition-colors cursor-pointer"
-                  @click="handleLinkClick(account.platform, account.url, blogger.name)"
-                >
-                  <span class="mr-1">{{ account.icon }}</span>
-                  {{ account.platform }}
-                </a>
-                <span
-                  v-else
-                  class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-gray-500 whitespace-nowrap opacity-60"
-                >
-                  <span class="mr-1">{{ account.icon }}</span>
-                  {{ account.platform }}
-                </span>
-              </template>
-
-              <button
-                v-if="hasOnlyOnePlatform(blogger)"
-                type="button"
-                class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-indigo-600 whitespace-nowrap hover:bg-indigo-100 hover:text-indigo-700 transition-colors cursor-pointer"
-                @click.stop="openMoreDataModal(blogger)"
-              >
-                平台补全中
-              </button>
-            </div>
-
-            <!-- 展开/收起按钮 -->
-            <button
-              @click="toggleExpanded(blogger.id)"
-              class="mt-4 w-full py-2 px-4 bg-indigo-50 hover:bg-indigo-100 text-indigo-700 rounded-lg transition-colors flex items-center justify-center group-hover:bg-indigo-600 group-hover:text-white"
-            >
-              <span>{{ expandedBloggers.includes(blogger.id) ? '收起详情' : '查看更多' }}</span>
-              <svg
-                class="ml-2 w-4 h-4 transform transition-transform"
-                :class="{ 'rotate-180': expandedBloggers.includes(blogger.id) }"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-              </svg>
-            </button>
-          </div>
-
-          <!-- 展开内容 -->
-          <transition
-            enter-active-class="transition-all duration-300 ease-out"
-            enter-from-class="opacity-0 max-h-0"
-            enter-to-class="opacity-100 max-h-96"
-            leave-active-class="transition-all duration-300 ease-in"
-            leave-from-class="opacity-100 max-h-96"
-            leave-to-class="opacity-0 max-h-0"
-          >
-            <div v-show="expandedBloggers.includes(blogger.id)" class="px-5 xl:px-4 pb-5 border-t border-gray-100 bg-gray-50/60 rounded-b-2xl">
-              <div class="pt-4 space-y-3 text-sm">
-                <!-- 专长领域 -->
-                <div>
-                  <h4 class="font-semibold text-gray-900 mb-1">专长领域</h4>
-                  <div class="flex flex-wrap gap-1.5">
-                    <span
-                      v-for="specialty in blogger.expandedContent.specialties"
-                      :key="specialty"
-                      class="px-2.5 py-0.5 bg-blue-100 text-blue-700 rounded-full"
-                    >
-                      {{ specialty }}
-                    </span>
-                  </div>
-                </div>
-
-                <!-- 成就荣誉 -->
-                <div>
-                  <h4 class="font-semibold text-gray-900 mb-1">成就荣誉</h4>
-                  <ul class="space-y-1">
-                    <li
-                      v-for="achievement in blogger.expandedContent.achievements"
-                      :key="achievement"
-                      class="text-gray-600 flex items-center"
-                    >
-                      <span class="text-green-500 mr-1.5">✓</span>
-                      {{ achievement }}
-                    </li>
-                  </ul>
-                </div>
-
-                <!-- 最近文章 -->
-                <div>
-                  <h4 class="font-semibold text-gray-900 mb-1">最近文章</h4>
-                  <ul class="space-y-1">
-                    <li
-                      v-for="post in blogger.expandedContent.recentPosts"
-                      :key="post"
-                      class="text-gray-600 flex items-center"
-                    >
-                      <span class="text-indigo-500 mr-1.5">📝</span>
-                      {{ post }}
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </transition>
-        </div>
-        
+          :blogger="blogger"
+          :expanded="expandedBloggers.includes(blogger.id)"
+          :is-kol="isKOL(blogger.followers)"
+          :is-koc="isKOC(blogger.followers)"
+          :has-only-one-platform="hasOnlyOnePlatform(blogger)"
+          :fallback-avatar="getFallbackAvatar(blogger.name)"
+          @toggle-expanded="toggleExpanded"
+          @link-click="handleLinkEvent"
+          @request-platforms="openMoreDataModal"
+          @avatar-error="handleAvatarError"
+        />
       </div>
 
-      <!-- 2. 表格视图 (Table View) -->
-      <div v-else class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
-        <div class="overflow-x-auto">
-          <table class="min-w-full divide-y divide-gray-200 table-fixed">
-            <thead class="bg-gray-50">
-              <tr>
-                <th
-                  scope="col"
-                  class="w-56 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider select-none sticky left-0 bg-gray-50 z-10 shadow-[2px_0_5px_rgba(0,0,0,0.05)]"
-                >
-                  博主信息
-                </th>
-                <th scope="col" class="w-40 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider select-none text-gray-400">
-                  粉丝基数
-                </th>
-                <th scope="col" class="w-80 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider">擅长领域</th>
-                <th scope="col" class="w-96 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider hidden md:table-cell">
-                  个人简介
-                </th>
-                <!-- 动态生成平台表头 -->
-                <th
-                  v-for="platform in availablePlatforms"
-                  :key="platform"
-                  scope="col"
-                  class="w-64 px-6 py-3 text-left text-xs font-bold text-gray-500 uppercase tracking-wider border-l border-gray-100"
-                >
-                  {{ platform }}
-                </th>
-              </tr>
-            </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
-              <tr v-for="blogger in filteredAndSortedBloggers" :key="blogger.id" class="hover:bg-gray-50 transition-colors">
-                <td class="px-6 py-4 whitespace-nowrap sticky left-0 bg-white group-hover:bg-gray-50 z-10 shadow-[2px_0_5px_rgba(0,0,0,0.05)]">
-                  <div class="flex items-center">
-                    <div class="flex-shrink-0 h-10 w-10">
-                      <img
-                        class="h-10 w-10 rounded-full border border-gray-200 object-cover"
-                        :src="blogger.avatar"
-                        :alt="blogger.name"
-                        :data-fallback-avatar="getFallbackAvatar(blogger.name)"
-                        @error="handleAvatarError"
-                      />
-                    </div>
-                    <div class="ml-4">
-                      <div class="text-sm font-medium text-gray-900">
-                        <span>{{ blogger.name }}</span>
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap">
-                  <span class="text-sm font-bold text-indigo-600">{{ blogger.followers }}</span>
-                </td>
-                <td class="px-6 py-4">
-                  <div class="flex flex-wrap gap-1">
-                    <span
-                      v-for="(specialty, idx) in blogger.expandedContent.specialties.slice(0, 3)"
-                      :key="idx"
-                      class="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-50 text-blue-700"
-                    >
-                      {{ specialty }}
-                    </span>
-                    <span v-if="blogger.expandedContent.specialties.length > 3" class="text-xs text-gray-400">...</span>
-                  </div>
-                </td>
-                <td class="px-6 py-4 hidden md:table-cell">
-                  <div class="text-sm text-gray-500 line-clamp-2 max-w-xs" :title="blogger.introduction">
-                    {{ blogger.introduction }}
-                  </div>
-                </td>
-                <!-- 动态生成平台数据 -->
-                <td v-for="platform in availablePlatforms" :key="platform" class="px-6 py-4 whitespace-nowrap">
-                  <div v-if="getAccountByPlatform(blogger, platform)" class="flex items-center gap-1.5">
-                    <span class="text-lg">{{ getAccountByPlatform(blogger, platform).icon }}</span>
-                    <a
-                      :href="getAccountByPlatform(blogger, platform).url"
-                      target="_blank"
-                      class="text-sm text-indigo-400 hover:text-indigo-600 underline truncate max-w-[120px] transition-colors"
-                      :title="getAccountByPlatform(blogger, platform).url"
-                      @click="
-                        handleLinkClick(getAccountByPlatform(blogger, platform).platform, getAccountByPlatform(blogger, platform).url, blogger.name)
-                      "
-                    >
-                      {{
-                        getAccountByPlatform(blogger, platform).platform.includes(":")
-                          ? getAccountByPlatform(blogger, platform).platform.split(":")[1]
-                          : "点击查看"
-                      }}
-                    </a>
-
-                    <button
-                      v-if="hasOnlyOnePlatform(blogger)"
-                      type="button"
-                      class="text-xs text-indigo-500 hover:text-indigo-700 underline ml-1"
-                      @click.stop="openMoreDataModal(blogger)"
-                    >
-                      平台补全中
-                    </button>
-                  </div>
-                  <span v-else class="text-gray-300 text-xs">-</span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-
-          <!-- 空状态提示 -->
-          <div v-if="filteredAndSortedBloggers.length === 0" class="p-8 text-center text-gray-500">没有找到匹配的博主，请尝试其他关键词。</div>
-        </div>
-        <div class="bg-gray-50 px-6 py-3 border-t border-gray-200 text-xs text-center text-gray-500">
-          提示：您可以直接复制表格内容，并粘贴到 Excel、Notion 或飞书中。
-        </div>
-      </div>
+      <BloggerTable
+        v-else
+        :bloggers="filteredAndSortedBloggers"
+        :available-platforms="availablePlatforms"
+        :fallback-avatar-for="getFallbackAvatar"
+        :has-only-one-platform="hasOnlyOnePlatform"
+        :get-account-by-platform="getAccountByPlatform"
+        @link-click="handleLinkEvent"
+        @request-platforms="openMoreDataModal"
+        @avatar-error="handleAvatarError"
+      />
     </section>
 
-    <!-- 底部 CTA 区域 -->
+    <!-- 底部 CTA -->
     <section id="join-cta" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div class="relative overflow-hidden rounded-[28px] border border-amber-200 bg-[linear-gradient(135deg,#fffdf7_0%,#fff7ed_48%,#fffefb_100%)] px-6 py-6 shadow-[0_20px_60px_rgba(120,53,15,0.08)] md:px-8">
         <div class="absolute right-6 top-5 rotate-6 text-2xl opacity-70">✉️</div>
@@ -617,57 +172,7 @@
       <span v-else>总PV {{ trafficStats.pv }} · 总UV {{ trafficStats.uv }} · 本页PV {{ trafficStats.pagePv }}</span>
     </div>
 
-    <!-- 右下角二维码 -->
-    <div v-if="!qrHidden" class="fixed bottom-6 right-6 z-50">
-      <div class="relative animate-float">
-        <!-- 背景装饰 -->
-        <div class="absolute inset-0 bg-gradient-to-br from-blue-400/20 to-purple-400/20 rounded-2xl blur-xl"></div>
-        
-        <!-- 二维码卡片 -->
-        <div class="relative bg-white/95 backdrop-blur-md rounded-2xl shadow-xl border border-white/50 p-2 w-52 hover:shadow-2xl hover:scale-105 transition-all duration-300">
-          <div class="mb-1">
-            <div class="relative">
-              <div class="h-6 flex items-center justify-center text-sm font-bold text-gray-800">合作与共创</div>
-              <div class="absolute right-0 top-0 h-6 flex items-center gap-1">
-                <button
-                  type="button"
-                  class="inline-flex items-center justify-center w-6 h-6 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                  :title="qrCollapsed ? '展开' : '收缩'"
-                  @click.stop="qrCollapsed = !qrCollapsed"
-                >
-                  <span class="text-base leading-none">{{ qrCollapsed ? '+' : '−' }}</span>
-                </button>
-                <button
-                  type="button"
-                  class="inline-flex items-center justify-center w-6 h-6 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                  title="关闭"
-                  @click.stop="qrHidden = true"
-                >
-                  <span class="text-base leading-none">×</span>
-                </button>
-              </div>
-            </div>
-            <div v-if="!qrCollapsed" class="text-center text-xs text-gray-500">扫码/添加微信号atar24</div>
-          </div>
-          
-          <div v-if="!qrCollapsed" class="bg-gray-50 p-1 rounded-xl">
-            <img 
-              src="/src/img/qrcode1.jpg" 
-              alt="微信二维码" 
-              class="w-full h-auto rounded-lg object-contain"
-              onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';"
-            />
-            <!-- 备用显示，如果图片加载失败 -->
-            <div class="w-full h-36 bg-gray-100 rounded-lg flex items-center justify-center hidden">
-              <div class="text-center">
-                <div class="text-xl mb-1">📱</div>
-                <div class="text-xs text-gray-500">二维码图片</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <QrCorner />
 
     <div v-if="moreDataModalOpen" class="fixed inset-0 z-[60] flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/40" @click="closeMoreDataModal"></div>
@@ -687,39 +192,30 @@
         </div>
       </div>
     </div>
-
-
-
-
-
-
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted, computed } from 'vue'
-import { bloggersData } from '../../data/bloggerInfo.js'
+import { bloggersData, cooperationHeatOrder } from '../../data/bloggerInfo.js'
 import { trackLinkClick } from '../../utils/hybridStats.js'
 import { getBloggerStats } from '../../utils/analytics.js'
 import { getRealTimeStats, recordPageView } from '../../utils/statsService.js'
 import bloggerRosterFile from '../../data/博主联盟花名册v20260106.xlsx?url'
+import BrandMarquee from '../../components/BrandMarquee.vue'
+import BloggerCard from '../../components/BloggerCard.vue'
+import BloggerTable from '../../components/BloggerTable.vue'
+import BloggerControls from '../../components/BloggerControls.vue'
+import QrCorner from '../../components/QrCorner.vue'
 
-// 响应式数据 - 直接初始化数据，无需加载状态
-const bloggers = ref(bloggersData)
 const expandedBloggers = ref([])
 const bloggerStats = ref(getBloggerStats())
 const trafficStats = computed(() => getRealTimeStats())
 
-const qrHidden = ref(false)
-const qrCollapsed = ref(false)
-
 const moreDataModalOpen = ref(false)
-const openMoreDataModal = () => {
-  moreDataModalOpen.value = true
-}
-const closeMoreDataModal = () => {
-  moreDataModalOpen.value = false
-}
+const openMoreDataModal = () => { moreDataModalOpen.value = true }
+const closeMoreDataModal = () => { moreDataModalOpen.value = false }
+
 const hasOnlyOnePlatform = (blogger) => (blogger?.socialAccounts?.length ?? 0) === 1
 
 const avatarPalette = [
@@ -731,10 +227,8 @@ const avatarPalette = [
 ]
 
 const getInitials = (name = '') => {
-  const normalized = String(name).trim()
-  if (!normalized) return '博'
-
-  const compact = normalized.replace(/\s+/g, '')
+  const compact = String(name).trim().replace(/\s+/g, '')
+  if (!compact) return '博'
   return compact.slice(0, Math.min(2, compact.length))
 }
 
@@ -748,18 +242,15 @@ const getFallbackAvatar = (name = '') => {
       <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" fill="${textColor}" font-family="Arial, PingFang SC, Microsoft YaHei, sans-serif" font-size="34" font-weight="700">${initials}</text>
     </svg>
   `
-
   return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`
 }
 
 const handleAvatarError = (event) => {
   const target = event?.target
   if (!(target instanceof HTMLImageElement)) return
-
-  const fallbackAvatar = target.dataset.fallbackAvatar || getFallbackAvatar(target.alt)
-  if (target.src === fallbackAvatar) return
-
-  target.src = fallbackAvatar
+  const fallback = target.dataset.fallbackAvatar || getFallbackAvatar(target.alt)
+  if (target.src === fallback) return
+  target.src = fallback
 }
 
 const parseFollowersValue = (followersStr) => {
@@ -770,23 +261,19 @@ const parseFollowersValue = (followersStr) => {
     const num = parseFloat(clean.replace('K', ''))
     return Number.isNaN(num) ? 0 : num * 1000
   }
-
   if (clean.includes('W')) {
     const num = parseFloat(clean.replace('W', ''))
     return Number.isNaN(num) ? 0 : num * 10000
   }
-
   if (clean.includes('M')) {
     const num = parseFloat(clean.replace('M', ''))
     return Number.isNaN(num) ? 0 : num * 1000000
   }
-
   const num = parseFloat(clean)
   return Number.isNaN(num) ? 0 : num
 }
 
 const KOL_THRESHOLD = 5000
-
 const isKOL = (followersStr) => parseFollowersValue(followersStr) > KOL_THRESHOLD
 const isKOC = (followersStr) => {
   const value = parseFollowersValue(followersStr)
@@ -798,11 +285,9 @@ const hasExplicitAvatar = (blogger) => {
   if (typeof avatar !== 'string') return false
   const trimmed = avatar.trim()
   if (!trimmed) return false
-  // dicebear 是占位头像，不算“明确头像”
   return !trimmed.includes('dicebear.com')
 }
 
-// 切换展开状态
 const toggleExpanded = (bloggerId) => {
   const index = expandedBloggers.value.indexOf(bloggerId)
   if (index > -1) {
@@ -812,42 +297,27 @@ const toggleExpanded = (bloggerId) => {
   }
 }
 
-// 处理链接点击
-const handleLinkClick = (platform, url, bloggerName) => {
-  console.log('链接被点击:', platform, url, bloggerName)
+const handleLinkEvent = ({ platform, url, bloggerName }) => {
   trackLinkClick(`${bloggerName}-${platform}`, url, '/tob')
 }
 
-// 滚动到博主团队部分
-const scrollToBloggerTeam = () => {
-  const element = document.getElementById('blogger-team')
-  if (element) {
-    element.scrollIntoView({
-      behavior: 'smooth',
-      block: 'start'
-    })
-  }
-}
-
 // --- 列表/表格视图与筛选排序逻辑 ---
-const viewMode = ref("grid"); // 'grid' | 'table'
-const selectedPlatform = ref("all"); // 平台筛选
-const sortField = ref("cooperationHeat"); // 'cooperationHeat' | 'recommended' | 'followers'
-const sortOrder = ref("desc"); // 'asc' | 'desc'
+const viewMode = ref('grid')
+const selectedPlatform = ref('all')
+const sortField = ref('cooperationHeat')
+const sortOrder = ref('desc')
 
-const bloggerOrderIndex = new Map(bloggersData.map((blogger, index) => [blogger.id, index]))
-const getBloggerOriginalIndex = (blogger) => bloggerOrderIndex.get(blogger.id) ?? Number.MAX_SAFE_INTEGER
-const cooperationHeatPriorityNames = ['安东尼', '主任', '前端之虎', '小包', '中杯可乐', '阿杆', '浪里行舟', 'ErpanOmer', '南方者', '万少']
+const bloggerOrderIndex = new Map(bloggersData.map((b, i) => [b.id, i]))
+const getBloggerOriginalIndex = (b) => bloggerOrderIndex.get(b.id) ?? Number.MAX_SAFE_INTEGER
 
 const getCooperationHeatPriority = (blogger) => {
-  const priorityIndex = cooperationHeatPriorityNames.findIndex((keyword) => blogger.name.includes(keyword))
-  return priorityIndex === -1 ? Number.MAX_SAFE_INTEGER : priorityIndex
+  const idx = cooperationHeatOrder.findIndex((kw) => blogger.name.includes(kw))
+  return idx === -1 ? Number.MAX_SAFE_INTEGER : idx
 }
 
 const compareByRecommendedOrder = (a, b) => {
   const hasA = hasExplicitAvatar(a)
   const hasB = hasExplicitAvatar(b)
-
   if (hasA !== hasB) return hasA ? -1 : 1
 
   if (hasA && hasB) {
@@ -862,115 +332,83 @@ const compareByRecommendedOrder = (a, b) => {
   return getBloggerOriginalIndex(a) - getBloggerOriginalIndex(b)
 }
 
-// 静态定义的常用平台，用于表头排序
-const staticPlatforms = ["掘金", "GitHub", "CSDN", "知乎", "微信公众号"];
+const staticPlatforms = ['掘金', 'GitHub', 'CSDN', '知乎', '微信公众号']
 
-// 计算所有出现在数据中的唯一平台（分组处理）
 const availablePlatforms = computed(() => {
-  const platforms = new Set();
+  const platforms = new Set()
   bloggersData.forEach((blogger) => {
     blogger.socialAccounts.forEach((acc) => {
-      let p = acc.platform;
-      if (p.includes("微信公众号")) p = "微信公众号";
-      if (p.includes("腾讯云")) p = "腾讯云";
-      platforms.add(p);
-    });
-  });
+      let p = acc.platform
+      if (p.includes('微信公众号')) p = '微信公众号'
+      if (p.includes('腾讯云')) p = '腾讯云'
+      platforms.add(p)
+    })
+  })
+  return Array.from(platforms).sort((a, b) => {
+    const idxA = staticPlatforms.indexOf(a)
+    const idxB = staticPlatforms.indexOf(b)
+    if (idxA !== -1 && idxB !== -1) return idxA - idxB
+    if (idxA !== -1) return -1
+    if (idxB !== -1) return 1
+    return a.localeCompare(b)
+  })
+})
 
-  const list = Array.from(platforms);
-  return list.sort((a, b) => {
-    const idxA = staticPlatforms.indexOf(a);
-    const idxB = staticPlatforms.indexOf(b);
-    if (idxA !== -1 && idxB !== -1) return idxA - idxB;
-    if (idxA !== -1) return -1;
-    if (idxB !== -1) return 1;
-    return a.localeCompare(b);
-  });
-});
-
-// 根据平台名称获取博主的账号信息（支持模糊匹配分组后的平台）
 const getAccountByPlatform = (blogger, platformName) => {
   return blogger.socialAccounts.find((acc) => {
-    if (platformName === "微信公众号") return acc.platform.includes("微信公众号");
-    if (platformName === "腾讯云") return acc.platform.includes("腾讯云");
-    return acc.platform === platformName;
-  });
-};
+    if (platformName === '微信公众号') return acc.platform.includes('微信公众号')
+    if (platformName === '腾讯云') return acc.platform.includes('腾讯云')
+    return acc.platform === platformName
+  })
+}
 
-// 复制表格数据到剪贴板 (TSV格式，方便粘贴到Excel)
 const copyTableToClipboard = () => {
-  const headers = ["博主姓名", "粉丝基数", "擅长领域", "个人简介", ...availablePlatforms.value];
+  const headers = ['博主姓名', '粉丝基数', '擅长领域', '个人简介', ...availablePlatforms.value]
 
   const rows = filteredAndSortedBloggers.value.map((blogger) => {
     const rowData = [
       blogger.name,
       blogger.followers,
-      blogger.expandedContent.specialties.join(", "),
-      blogger.introduction.replace(/\n|\r/g, " "), // 简介放到领域后
-    ];
-
-    // 平台链接
+      blogger.expandedContent.specialties.join(', '),
+      blogger.introduction.replace(/\n|\r/g, ' ')
+    ]
     availablePlatforms.value.forEach((p) => {
-      const acc = getAccountByPlatform(blogger, p);
-      rowData.push(acc ? acc.url : "-");
-    });
+      const acc = getAccountByPlatform(blogger, p)
+      rowData.push(acc ? acc.url : '-')
+    })
+    return rowData.join('\t')
+  })
 
-    return rowData.join("\t");
-  });
-
-  const tsvHeader = headers.join("\t");
-  const tsvBody = rows.join("\n");
-  const finalContent = `${tsvHeader}\n${tsvBody}`;
+  const finalContent = `${headers.join('\t')}\n${rows.join('\n')}`
 
   navigator.clipboard
     .writeText(finalContent)
-    .then(() => {
-      alert("✅ 表格数据已复制！\n\n您现在可以直接在 Excel、飞书或 Notion 中粘贴。");
-    })
-    .catch((err) => {
-      console.error("复制失败:", err);
-      alert("复制失败，请重试");
-    });
-};
+    .then(() => alert('✅ 表格数据已复制！\n\n您现在可以直接在 Excel、飞书或 Notion 中粘贴。'))
+    .catch(() => alert('复制失败，请重试'))
+}
 
-// 计算属性：筛选和排序后的博主列表
 const filteredAndSortedBloggers = computed(() => {
-  let result = [...bloggersData];
+  let result = [...bloggersData]
 
-  // 1. 平台筛选
-  if (selectedPlatform.value !== "all") {
-    result = result.filter((blogger) => getAccountByPlatform(blogger, selectedPlatform.value));
+  if (selectedPlatform.value !== 'all') {
+    result = result.filter((blogger) => getAccountByPlatform(blogger, selectedPlatform.value))
   }
 
-  // 2. 排序
-  if (sortField.value === "cooperationHeat") {
+  if (sortField.value === 'cooperationHeat') {
     result.sort((a, b) => {
       const priorityA = getCooperationHeatPriority(a)
       const priorityB = getCooperationHeatPriority(b)
-
-      if (priorityA !== priorityB) {
-        return priorityA - priorityB
-      }
-
+      if (priorityA !== priorityB) return priorityA - priorityB
       return compareByRecommendedOrder(a, b)
     })
-  } else if (sortField.value === "recommended") {
-    // 合作推荐：明确头像优先；有头像时 KOL 在前、KOC 在后（组内保持原顺序）；无明确头像按粉丝量降序
+  } else if (sortField.value === 'recommended') {
+    result.sort(compareByRecommendedOrder)
+  } else if (sortField.value === 'followers') {
     result.sort((a, b) => {
-      return compareByRecommendedOrder(a, b)
-    })
-  } else {
-    result.sort((a, b) => {
-      let valA
-      let valB
-
-      if (sortField.value === "followers") {
-        valA = parseFollowersValue(a.followers)
-        valB = parseFollowersValue(b.followers)
-      }
-
-      if (valA < valB) return sortOrder.value === "asc" ? -1 : 1
-      if (valA > valB) return sortOrder.value === "asc" ? 1 : -1
+      const valA = parseFollowersValue(a.followers)
+      const valB = parseFollowersValue(b.followers)
+      if (valA < valB) return sortOrder.value === 'asc' ? -1 : 1
+      if (valA > valB) return sortOrder.value === 'asc' ? 1 : -1
       return 0
     })
   }
@@ -978,39 +416,7 @@ const filteredAndSortedBloggers = computed(() => {
   return result
 })
 
-// 页面加载时记录访问
 onMounted(() => {
   recordPageView()
 })
 </script>
-
-<style scoped>
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
-}
-
-.animate-float {
-  animation: float 3s ease-in-out infinite;
-}
-
-@keyframes nudgeX {
-  0%, 100% {
-    transform: translateX(0);
-  }
-  50% {
-    transform: translateX(6px);
-  }
-}
-
-.animate-nudge-x {
-  animation: nudgeX 0.9s ease-in-out infinite;
-  will-change: transform;
-}
-</style>
-
- 

--- a/src/style.css
+++ b/src/style.css
@@ -119,4 +119,13 @@
   .animate-scroll:hover {
     animation-play-state: paused;
   }
-} 
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-scroll,
+    .animate-pulse,
+    .animate-float,
+    .animate-nudge-x {
+      animation: none !important;
+    }
+  }
+}

--- a/src/utils/hybridStats.js
+++ b/src/utils/hybridStats.js
@@ -37,14 +37,10 @@ export function getHybridStats() {
 
 // 记录用户交互事件
 export function trackUserInteraction(eventName, parameters = {}) {
-  // 发送到 Google Analytics
   trackEvent(eventName, {
     ...parameters,
     timestamp: new Date().toISOString()
   })
-  
-  // 也可以记录到本地存储（可选）
-  console.log('User interaction tracked:', eventName, parameters)
 }
 
 // 记录按钮点击


### PR DESCRIPTION
## Summary

第二档重构 PR：聚焦 `src/pages/tob/index.vue` 的可维护性。

> 基于 [#22](https://github.com/TUARAN/blogger-alliance/pull/22) 分支，需在 #22 合并后再合本 PR；GitHub 会在 #22 合并后自动把 base 切到 main。

### 主页拆分
`src/pages/tob/index.vue` 1041 行 → **422 行**（−619 行）。拆出 5 个职责清晰的组件：

| 组件 | 行数 | 作用 |
|---|---|---|
| [BrandMarquee.vue](src/components/BrandMarquee.vue) | 21 | 已合作品牌横向轮播 |
| [BloggerCard.vue](src/components/BloggerCard.vue) | 161 | 卡片视图里的单张博主卡片 |
| [BloggerTable.vue](src/components/BloggerTable.vue) | 126 | 表格视图（可水平滚动 + 平台列） |
| [BloggerControls.vue](src/components/BloggerControls.vue) | 109 | 顶部筛选/排序/视图切换栏 |
| [QrCorner.vue](src/components/QrCorner.vue) | 65 | 右下角合作二维码（自带可关闭/可收起状态） |

### 数据化
- 品牌轮播：删掉 hard-code 重复两遍的 8 个品牌 div，新增 `partnerBrands` 数据源 + `v-for` 渲染两轮
- 排序优先级：`cooperationHeatPriorityNames` 硬编码姓名列表 → 移到 `bloggerInfo.js` 的 `cooperationHeatOrder`，重排首页热度顺序无需改页面代码

### 无障碍
- `src/style.css` 给 `animate-scroll` / `animate-pulse` / `animate-float` / `animate-nudge-x` 统一加 `prefers-reduced-motion: reduce` 兜底
- `QrCorner` 内的 `@keyframes float` 也走相同规则

### 生产噪音
- `hybridStats.trackUserInteraction` 里 \`console.log('User interaction tracked', ...)\` 已删
- `tob/index.vue` 中每次链接点击的 \`console.log\` 已删（GA 事件继续发）
- 全仓 `grep "console\.log"` 现已为零（保留 `console.error`/`console.warn`）

## Test plan

- [x] `npm run build` 通过
- [x] `/` 渲染 40 张博主卡片 + 品牌轮播 + Hero 统计正常
- [x] 表格视图切换正常，表头含"博主信息/粉丝基数/擅长领域/个人简介/掘金/GitHub..."
- [x] 卡片视图首屏前 6 位顺序符合 `cooperationHeatOrder`：掘金安东尼/德育处主任/前端之虎陈随易/战场小包/中杯可乐多加冰/阿杆
- [x] 桌面 1280×800 截图 hero / 轮播 / 二维码 角标位置正确

## 后续 PR（仍未做，欢迎独立提）

- `alert()` → toast：复制成功 / web-llm 错误反馈
- 三套统计合并：`statsService` + `analytics` + `busuanzi` + `hybridStats` 现有四层调用关系混乱

🤖 Generated with [Claude Code](https://claude.com/claude-code)