### PR TITLE
feat(ui): 首页与服务总览重构 — 定价对比表 + 定位&优势 + 视觉层级

### DIFF
--- a/src/components/AppNav.vue
+++ b/src/components/AppNav.vue
@@ -1,10 +1,35 @@
 <script setup>
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import { useRoute } from 'vue-router'
+
 const navLinks = [
   { label: '服务介绍', to: '/tob/services' },
-  { label: '矩阵看板', to: '/matrix' },
-  { label: '联盟学院', to: { path: '/academy', query: { tab: 'knowledge' } } },
-  { label: '内部数据', to: '/tob/internal' }
+  { label: '案例', to: '/cases' },
+  { label: '联盟学院', to: { path: '/academy', query: { tab: 'knowledge' } } }
 ]
+
+const workspaceMenu = [
+  { label: '工作总览', to: '/workspace', kind: 'router' },
+  { label: '矩阵看板', to: '/matrix', kind: 'router' },
+  { label: '内部数据', to: '/tob/internal', kind: 'router' },
+  { label: '同步工具', href: 'https://md.tuaran666.workers.dev/', kind: 'external' }
+]
+
+const route = useRoute()
+const workspaceOpen = ref(false)
+const workspaceRef = ref(null)
+
+const workspaceActiveRoute = computed(() =>
+  ['/workspace', '/matrix', '/tob/internal'].some((p) => route.path.startsWith(p))
+)
+
+const onDocClick = (e) => {
+  if (!workspaceRef.value) return
+  if (!workspaceRef.value.contains(e.target)) workspaceOpen.value = false
+}
+
+onMounted(() => document.addEventListener('click', onDocClick))
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
 
 defineProps({
   logoTo: { type: String, default: '/tob' },
@@ -13,57 +38,87 @@ defineProps({
 </script>
 
 <template>
-  <nav class="bg-white/80 backdrop-blur-md shadow-sm border-b sticky top-0 z-40">
+  <nav class="bg-white/85 backdrop-blur-md border-b border-slate-200/70 sticky top-0 z-40">
     <div class="mx-auto max-w-[1500px] px-3 sm:px-4 lg:px-5">
       <div class="flex justify-between items-center h-16 gap-4">
         <div class="flex items-center min-w-0">
           <router-link
             :to="logoTo"
-            class="text-xl font-bold text-indigo-600 hover:text-indigo-800 transition-colors truncate"
+            class="text-base sm:text-lg font-semibold text-slate-900 hover:text-indigo-700 transition-colors truncate tracking-tight"
           >
-            🚀开发者博主联盟
+            <span class="mr-1.5" aria-hidden="true">🚀</span>开发者博主联盟
           </router-link>
         </div>
 
         <div class="flex min-w-0 items-center gap-4 ml-4 md:ml-8 lg:ml-10">
-          <div class="hidden items-center gap-6 text-sm font-semibold text-slate-500 md:flex">
+          <div class="hidden items-center gap-6 text-sm font-medium text-slate-600 md:flex">
             <router-link
               v-for="item in navLinks"
               :key="item.label"
               :to="item.to"
-              class="relative whitespace-nowrap transition-colors hover:text-indigo-700 after:absolute after:-bottom-1.5 after:left-0 after:h-0.5 after:w-0 after:bg-indigo-600 after:transition-all hover:after:w-full"
-              active-class="text-indigo-700 after:w-full"
+              class="relative whitespace-nowrap transition-colors hover:text-slate-900 after:absolute after:-bottom-1.5 after:left-0 after:h-px after:w-0 after:bg-slate-900 after:transition-all hover:after:w-full"
+              active-class="text-slate-900 after:w-full"
             >
               {{ item.label }}
             </router-link>
-            <router-link
-              to="/workspace"
-              class="relative whitespace-nowrap transition-colors hover:text-indigo-700 after:absolute after:-bottom-1.5 after:left-0 after:h-0.5 after:w-0 after:bg-indigo-600 after:transition-all hover:after:w-full"
-              active-class="text-indigo-700 after:w-full"
-            >
-              工作总览
-            </router-link>
-            <a
-              href="https://md.tuaran666.workers.dev/"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="relative inline-flex items-center gap-1 whitespace-nowrap transition-colors hover:text-indigo-700 after:absolute after:-bottom-1.5 after:left-0 after:h-0.5 after:w-0 after:bg-indigo-600 after:transition-all hover:after:w-full"
-            >
-              同步工具
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                class="h-3.5 w-3.5 shrink-0 opacity-70"
-                aria-hidden="true"
+
+            <div ref="workspaceRef" class="relative">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 whitespace-nowrap transition-colors hover:text-slate-900"
+                :class="workspaceActiveRoute ? 'text-slate-900' : ''"
+                @click.stop="workspaceOpen = !workspaceOpen"
               >
-                <path
-                  fill-rule="evenodd"
-                  d="M4.25 5.5a.75.75 0 01.75-.75h8a.75.75 0 01.75.75v8a.75.75 0 01-1.5 0V7.56l-6.22 6.22a.75.75 0 11-1.06-1.06l6.22-6.22H5a.75.75 0 010-1.5z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </a>
+                工作台
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  class="h-3 w-3 shrink-0 opacity-60 transition-transform"
+                  :class="workspaceOpen ? 'rotate-180' : ''"
+                  aria-hidden="true"
+                >
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+              <transition
+                enter-active-class="transition duration-150 ease-out"
+                enter-from-class="opacity-0 -translate-y-1"
+                enter-to-class="opacity-100 translate-y-0"
+                leave-active-class="transition duration-100 ease-in"
+                leave-from-class="opacity-100 translate-y-0"
+                leave-to-class="opacity-0 -translate-y-1"
+              >
+                <div
+                  v-show="workspaceOpen"
+                  class="absolute right-0 mt-2 w-44 rounded-xl border border-slate-200 bg-white shadow-lg py-1.5"
+                >
+                  <template v-for="item in workspaceMenu" :key="item.label">
+                    <router-link
+                      v-if="item.kind === 'router'"
+                      :to="item.to"
+                      class="block px-4 py-2 text-sm text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                      @click="workspaceOpen = false"
+                    >
+                      {{ item.label }}
+                    </router-link>
+                    <a
+                      v-else
+                      :href="item.href"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex items-center justify-between px-4 py-2 text-sm text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                      @click="workspaceOpen = false"
+                    >
+                      <span>{{ item.label }}</span>
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5 opacity-50" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 01.75-.75h8a.75.75 0 01.75.75v8a.75.75 0 01-1.5 0V7.56l-6.22 6.22a.75.75 0 11-1.06-1.06l6.22-6.22H5a.75.75 0 010-1.5z" clip-rule="evenodd" />
+                      </svg>
+                    </a>
+                  </template>
+                </div>
+              </transition>
+            </div>
           </div>
           <slot name="links"></slot>
           <WebLlmNavBot />

--- a/src/components/BloggerCard.vue
+++ b/src/components/BloggerCard.vue
@@ -12,21 +12,19 @@ const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 
 </script>
 
 <template>
-  <div class="group bg-white rounded-2xl shadow-md hover:shadow-lg transition-all duration-300 border border-gray-100 flex flex-col h-full">
+  <div class="group bg-white rounded-2xl border border-slate-200 hover:border-slate-300 hover:shadow-sm transition-all duration-300 flex flex-col h-full">
     <div class="relative p-5 xl:p-4 flex flex-col flex-1">
       <span
         v-if="isKol"
-        class="absolute -top-3 -right-3 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-white/95 border border-amber-300/70 text-amber-600 text-xs font-semibold shadow-sm"
+        class="absolute -top-2.5 -right-2.5 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-slate-900 text-white text-[10px] font-medium tracking-wide shadow-sm"
       >
-        <span class="text-base leading-none">✨</span>
-        <span class="pr-1">KOL</span>
+        <span>KOL</span>
       </span>
       <span
         v-else-if="isKoc"
-        class="absolute -top-3 -right-3 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-white/95 border border-sky-300/80 text-sky-600 text-xs font-semibold shadow-sm"
+        class="absolute -top-2.5 -right-2.5 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-white border border-slate-300 text-slate-700 text-[10px] font-medium tracking-wide shadow-sm"
       >
-        <span class="text-base leading-none">🌟</span>
-        <span class="pr-1">KOC</span>
+        <span>KOC</span>
       </span>
 
       <div class="mb-4">
@@ -38,22 +36,22 @@ const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 
             loading="lazy"
             decoding="async"
             @error="emit('avatar-error', $event)"
-            class="w-14 h-14 rounded-full object-cover border border-indigo-100 group-hover:border-indigo-300 transition-colors"
+            class="w-14 h-14 rounded-full object-cover border border-slate-200 group-hover:border-slate-300 transition-colors"
           />
         </div>
 
         <div class="mt-3 min-w-0">
           <div class="w-full text-center">
             <span class="relative inline-block max-w-full">
-              <span class="text-lg font-semibold text-gray-900 whitespace-normal break-words leading-snug group-hover:text-indigo-600 transition-colors">
+              <span class="text-lg font-semibold text-slate-900 whitespace-normal break-words leading-snug transition-colors">
                 {{ blogger.name }}
               </span>
-              <span class="absolute left-full ml-2 top-1/2 -translate-y-1/2 text-sm font-medium text-indigo-600 whitespace-nowrap">
+              <span class="absolute left-full ml-2 top-1/2 -translate-y-1/2 text-xs font-medium text-slate-500 whitespace-nowrap tabular-nums">
                 {{ blogger.followers }}
               </span>
             </span>
           </div>
-          <p class="text-xs text-gray-500 mt-1 leading-snug line-clamp-3">{{ blogger.introduction }}</p>
+          <p class="text-xs text-slate-500 mt-1 leading-snug line-clamp-3">{{ blogger.introduction }}</p>
         </div>
       </div>
 
@@ -64,17 +62,17 @@ const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 
             :href="account.url"
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-gray-700 whitespace-nowrap hover:bg-indigo-100 hover:text-indigo-700 transition-colors cursor-pointer"
+            class="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] text-slate-600 border border-slate-200 whitespace-nowrap hover:border-slate-400 hover:text-slate-900 transition-colors cursor-pointer"
             @click="emit('link-click', { platform: account.platform, url: account.url, bloggerName: blogger.name })"
           >
-            <span class="mr-1">{{ account.icon }}</span>
+            <span class="mr-1 opacity-80">{{ account.icon }}</span>
             {{ account.platform }}
           </a>
           <span
             v-else
-            class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-gray-500 whitespace-nowrap opacity-60"
+            class="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] text-slate-400 border border-slate-100 whitespace-nowrap"
           >
-            <span class="mr-1">{{ account.icon }}</span>
+            <span class="mr-1 opacity-80">{{ account.icon }}</span>
             {{ account.platform }}
           </span>
         </template>
@@ -82,7 +80,7 @@ const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 
         <button
           v-if="hasOnlyOnePlatform"
           type="button"
-          class="inline-flex items-center px-2.5 py-1 bg-gray-100 rounded-full text-xs text-indigo-600 whitespace-nowrap hover:bg-indigo-100 hover:text-indigo-700 transition-colors cursor-pointer"
+          class="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] text-slate-500 border border-dashed border-slate-300 whitespace-nowrap hover:border-slate-400 hover:text-slate-700 transition-colors cursor-pointer"
           @click.stop="emit('request-platforms', blogger)"
         >
           平台补全中
@@ -91,11 +89,11 @@ const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 
 
       <button
         @click="emit('toggle-expanded', blogger.id)"
-        class="mt-4 w-full py-2 px-4 bg-indigo-50 hover:bg-indigo-100 text-indigo-700 rounded-lg transition-colors flex items-center justify-center group-hover:bg-indigo-600 group-hover:text-white"
+        class="mt-4 w-full py-2 px-3 text-sm text-slate-600 rounded-lg border border-slate-200 hover:border-slate-400 hover:text-slate-900 transition-colors flex items-center justify-center"
       >
         <span>{{ expanded ? '收起详情' : '查看更多' }}</span>
         <svg
-          class="ml-2 w-4 h-4 transform transition-transform"
+          class="ml-1.5 w-3.5 h-3.5 transform transition-transform"
           :class="{ 'rotate-180': expanded }"
           fill="none"
           stroke="currentColor"
@@ -114,15 +112,15 @@ const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 
       leave-from-class="opacity-100 max-h-96"
       leave-to-class="opacity-0 max-h-0"
     >
-      <div v-show="expanded" class="px-5 xl:px-4 pb-5 border-t border-gray-100 bg-gray-50/60 rounded-b-2xl">
+      <div v-show="expanded" class="px-5 xl:px-4 pb-5 border-t border-slate-100 bg-slate-50/50 rounded-b-2xl">
         <div class="pt-4 space-y-3 text-sm">
           <div>
-            <h4 class="font-semibold text-gray-900 mb-1">专长领域</h4>
+            <h4 class="font-medium text-slate-900 mb-1.5 text-xs uppercase tracking-wider">专长领域</h4>
             <div class="flex flex-wrap gap-1.5">
               <span
                 v-for="specialty in blogger.expandedContent.specialties"
                 :key="specialty"
-                class="px-2.5 py-0.5 bg-blue-100 text-blue-700 rounded-full"
+                class="px-2 py-0.5 bg-white border border-slate-200 text-slate-700 rounded-md text-xs"
               >
                 {{ specialty }}
               </span>
@@ -130,28 +128,28 @@ const emit = defineEmits(['toggle-expanded', 'link-click', 'request-platforms', 
           </div>
 
           <div>
-            <h4 class="font-semibold text-gray-900 mb-1">成就荣誉</h4>
+            <h4 class="font-medium text-slate-900 mb-1.5 text-xs uppercase tracking-wider">成就荣誉</h4>
             <ul class="space-y-1">
               <li
                 v-for="achievement in blogger.expandedContent.achievements"
                 :key="achievement"
-                class="text-gray-600 flex items-center"
+                class="text-slate-600 flex items-start"
               >
-                <span class="text-green-500 mr-1.5">✓</span>
+                <span class="text-slate-400 mr-1.5">·</span>
                 {{ achievement }}
               </li>
             </ul>
           </div>
 
           <div>
-            <h4 class="font-semibold text-gray-900 mb-1">最近文章</h4>
+            <h4 class="font-medium text-slate-900 mb-1.5 text-xs uppercase tracking-wider">最近文章</h4>
             <ul class="space-y-1">
               <li
                 v-for="post in blogger.expandedContent.recentPosts"
                 :key="post"
-                class="text-gray-600 flex items-center"
+                class="text-slate-600 flex items-start"
               >
-                <span class="text-indigo-500 mr-1.5">📝</span>
+                <span class="text-slate-400 mr-1.5">·</span>
                 {{ post }}
               </li>
             </ul>

--- a/src/components/BloggerControls.vue
+++ b/src/components/BloggerControls.vue
@@ -25,14 +25,14 @@ const toggleOrder = (current) => emit('update:sortOrder', current === 'asc' ? 'd
 </script>
 
 <template>
-  <div class="mb-8 flex flex-col md:flex-row justify-between items-center gap-4 bg-white p-4 rounded-xl shadow-sm border border-gray-100">
-    <div class="flex flex-wrap items-center gap-4 w-full md:w-auto">
+  <div class="mb-8 flex flex-col md:flex-row justify-between items-center gap-3">
+    <div class="flex flex-wrap items-center gap-3 w-full md:w-auto">
       <div class="flex items-center gap-2">
-        <span class="text-sm text-gray-500 whitespace-nowrap">筛选平台:</span>
+        <span class="text-xs text-slate-500 whitespace-nowrap">筛选</span>
         <select
           :value="selectedPlatform"
           @change="emit('update:selectedPlatform', $event.target.value)"
-          class="block w-40 pl-3 pr-10 h-10 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md border"
+          class="block w-36 pl-3 pr-8 h-9 text-sm border-slate-200 bg-white focus:outline-none focus:ring-1 focus:ring-slate-400 focus:border-slate-400 rounded-md border text-slate-700"
         >
           <option value="all">全部平台</option>
           <option v-for="platform in availablePlatforms" :key="platform" :value="platform">
@@ -42,11 +42,11 @@ const toggleOrder = (current) => emit('update:sortOrder', current === 'asc' ? 'd
       </div>
 
       <div class="flex items-center gap-2">
-        <span class="text-sm text-gray-500 whitespace-nowrap">排序:</span>
+        <span class="text-xs text-slate-500 whitespace-nowrap">排序</span>
         <select
           :value="sortField"
           @change="onSortFieldChange"
-          class="block w-40 md:w-44 pl-3 pr-10 h-10 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md border"
+          class="block w-36 md:w-40 pl-3 pr-8 h-9 text-sm border-slate-200 bg-white focus:outline-none focus:ring-1 focus:ring-slate-400 focus:border-slate-400 rounded-md border text-slate-700"
         >
           <option value="cooperationHeat">合作热度</option>
           <option value="recommended">合作推荐</option>
@@ -55,55 +55,56 @@ const toggleOrder = (current) => emit('update:sortOrder', current === 'asc' ? 'd
         <button
           v-if="!['cooperationHeat', 'recommended'].includes(sortField)"
           @click="toggleOrder(sortOrder)"
-          class="flex items-center justify-center w-10 h-10 text-gray-500 hover:text-indigo-600 border border-gray-300 rounded-md transition-colors bg-white shadow-sm"
+          class="flex items-center justify-center w-9 h-9 text-slate-500 hover:text-slate-900 border border-slate-200 rounded-md transition-colors bg-white"
           title="切换升序/降序"
         >
-          <span class="text-lg leading-none">{{ sortOrder === 'asc' ? '⬆️' : '⬇️' }}</span>
+          <span class="text-sm leading-none">{{ sortOrder === 'asc' ? '↑' : '↓' }}</span>
         </button>
       </div>
     </div>
 
-    <div class="flex items-center gap-3 w-full md:w-auto justify-between md:justify-end">
-      <div class="flex bg-gray-100 p-1 rounded-lg shrink-0">
-        <a
-          :href="rosterFile"
-          download="博主联盟花名册v20260106.xlsx"
-          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1 bg-white text-indigo-600 shadow-sm hover:text-indigo-700"
-          title="下载博主联盟花名册到本地"
-        >
-          <span>⬇️</span>
-          <span class="hidden sm:inline">下载到本地</span>
-        </a>
-
-        <button
-          v-if="viewMode === 'table'"
-          @click="emit('copy-table')"
-          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1 text-gray-500 hover:text-green-700"
-          title="复制当前表格数据到剪贴板，可直接粘贴到Excel"
-        >
-          <span>📋</span>
-          <span class="hidden sm:inline">复制表格数据</span>
-        </button>
-      </div>
-
-      <div class="flex bg-gray-100 p-1 rounded-lg shrink-0">
+    <div class="flex items-center gap-2 w-full md:w-auto justify-between md:justify-end">
+      <!-- 视图切换 (icon-only) -->
+      <div class="flex border border-slate-200 rounded-md p-0.5 shrink-0 bg-white">
         <button
           @click="emit('update:viewMode', 'grid')"
-          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1"
-          :class="viewMode === 'grid' ? 'bg-white text-indigo-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
+          class="w-8 h-8 rounded transition-colors flex items-center justify-center"
+          :class="viewMode === 'grid' ? 'bg-slate-900 text-white' : 'text-slate-500 hover:text-slate-900'"
+          title="卡片视图"
+          aria-label="卡片视图"
         >
-          <span>📷</span>
-          <span class="hidden sm:inline">卡片</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path d="M3 4.75A1.75 1.75 0 014.75 3h3.5A1.75 1.75 0 0110 4.75v3.5A1.75 1.75 0 018.25 10h-3.5A1.75 1.75 0 013 8.25v-3.5zm9 0A1.75 1.75 0 0113.75 3h3.5A1.75 1.75 0 0119 4.75v3.5A1.75 1.75 0 0117.25 10h-3.5A1.75 1.75 0 0112 8.25v-3.5zm-9 9A1.75 1.75 0 014.75 12h3.5A1.75 1.75 0 0110 13.75v3.5A1.75 1.75 0 018.25 19h-3.5A1.75 1.75 0 013 17.25v-3.5zm9 0A1.75 1.75 0 0113.75 12h3.5A1.75 1.75 0 0119 13.75v3.5A1.75 1.75 0 0117.25 19h-3.5A1.75 1.75 0 0112 17.25v-3.5z" /></svg>
         </button>
         <button
           @click="emit('update:viewMode', 'table')"
-          class="px-3 py-1.5 rounded-md text-sm font-medium transition-all flex items-center gap-1"
-          :class="viewMode === 'table' ? 'bg-white text-indigo-600 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
+          class="w-8 h-8 rounded transition-colors flex items-center justify-center"
+          :class="viewMode === 'table' ? 'bg-slate-900 text-white' : 'text-slate-500 hover:text-slate-900'"
+          title="表格视图"
+          aria-label="表格视图"
         >
-          <span>📋</span>
-          <span class="hidden sm:inline">表格</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5zm2 0v3h4V5H5zm6 0v3h4V5h-4zM5 10v3h4v-3H5zm6 0v3h4v-3h-4zM5 15v0h4v0H5zm6 0v0h4v0h-4z" clip-rule="evenodd" /></svg>
         </button>
       </div>
+
+      <!-- 工具按钮 (icon-only) -->
+      <a
+        :href="rosterFile"
+        download="博主联盟花名册v20260106.xlsx"
+        class="flex items-center justify-center w-9 h-9 text-slate-500 hover:text-slate-900 border border-slate-200 rounded-md bg-white transition-colors"
+        title="下载博主联盟花名册"
+        aria-label="下载花名册"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path fill-rule="evenodd" d="M10 2a.75.75 0 01.75.75v8.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 111.06-1.06l3.22 3.22V2.75A.75.75 0 0110 2zM3.75 16a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H3.75z" clip-rule="evenodd" /></svg>
+      </a>
+      <button
+        v-if="viewMode === 'table'"
+        @click="emit('copy-table')"
+        class="flex items-center justify-center w-9 h-9 text-slate-500 hover:text-slate-900 border border-slate-200 rounded-md bg-white transition-colors"
+        title="复制表格数据到剪贴板"
+        aria-label="复制表格"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" /><path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" /></svg>
+      </button>
     </div>
   </div>
 </template>

--- a/src/components/QrCorner.vue
+++ b/src/components/QrCorner.vue
@@ -1,46 +1,66 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import qrcodeImage from '../img/qrcode1.jpg'
 
 const hidden = ref(false)
-const collapsed = ref(false)
+const collapsed = ref(true)
+const mounted = ref(false)
+
+onMounted(() => {
+  setTimeout(() => { mounted.value = true }, 1800)
+})
 </script>
 
 <template>
-  <div v-if="!hidden" class="fixed bottom-6 right-6 z-50">
-    <div class="relative animate-float">
-      <div class="absolute inset-0 bg-gradient-to-br from-blue-400/20 to-purple-400/20 rounded-2xl blur-xl"></div>
+  <transition
+    enter-active-class="transition duration-300 ease-out"
+    enter-from-class="opacity-0 translate-y-2"
+    enter-to-class="opacity-100 translate-y-0"
+  >
+    <div v-if="mounted && !hidden" class="fixed bottom-5 right-5 z-50">
+      <!-- Collapsed pill -->
+      <button
+        v-if="collapsed"
+        type="button"
+        class="group inline-flex items-center gap-2 rounded-full bg-slate-900 text-white pl-3.5 pr-4 py-2.5 text-sm font-medium shadow-lg hover:bg-slate-800 transition-colors"
+        @click="collapsed = false"
+        aria-label="展开二维码"
+      >
+        <span class="text-base leading-none" aria-hidden="true">🤝</span>
+        <span>联系合作</span>
+      </button>
 
-      <div class="relative bg-white/95 backdrop-blur-md rounded-2xl shadow-xl border border-white/50 p-1.5 w-40 hover:shadow-2xl hover:scale-105 transition-all duration-300">
-        <div class="mb-0.5">
-          <div class="relative">
-            <div class="h-6 flex items-center justify-center gap-1 pr-12 text-xs font-bold text-gray-800">
-              <span class="text-sm leading-none" aria-hidden="true">🔥</span>
-              <span>我要合作</span>
-            </div>
-            <div class="absolute right-0 top-0 h-6 flex items-center gap-0.5">
-              <button
-                type="button"
-                class="inline-flex items-center justify-center w-5 h-5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                :title="collapsed ? '展开' : '收缩'"
-                @click.stop="collapsed = !collapsed"
-              >
-                <span class="text-sm leading-none">{{ collapsed ? '+' : '−' }}</span>
-              </button>
-              <button
-                type="button"
-                class="inline-flex items-center justify-center w-5 h-5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                title="关闭"
-                @click.stop="hidden = true"
-              >
-                <span class="text-sm leading-none">×</span>
-              </button>
-            </div>
+      <!-- Expanded card -->
+      <div
+        v-else
+        class="relative bg-white rounded-2xl shadow-xl border border-slate-200 p-2 w-44"
+      >
+        <div class="flex items-center justify-between pl-1 pr-0.5">
+          <div class="inline-flex items-center gap-1.5 text-xs font-semibold text-slate-800">
+            <span aria-hidden="true">🤝</span>
+            <span>联系合作</span>
           </div>
-          <div v-if="!collapsed" class="text-center text-[10px] leading-tight text-gray-500 px-0.5">微信扫码 · atar24</div>
+          <div class="flex items-center gap-0.5">
+            <button
+              type="button"
+              class="inline-flex items-center justify-center w-5 h-5 rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors"
+              title="收起"
+              @click.stop="collapsed = true"
+            >
+              <span class="text-base leading-none">−</span>
+            </button>
+            <button
+              type="button"
+              class="inline-flex items-center justify-center w-5 h-5 rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors"
+              title="关闭"
+              @click.stop="hidden = true"
+            >
+              <span class="text-sm leading-none">×</span>
+            </button>
+          </div>
         </div>
-
-        <div v-if="!collapsed" class="bg-gray-50 p-0.5 rounded-lg">
+        <div class="text-center text-[10px] leading-tight text-slate-500 mt-0.5">微信扫码 · atar24</div>
+        <div class="mt-1.5 bg-slate-50 p-0.5 rounded-lg">
           <img
             :src="qrcodeImage"
             alt="微信二维码"
@@ -49,20 +69,5 @@ const collapsed = ref(false)
         </div>
       </div>
     </div>
-  </div>
+  </transition>
 </template>
-
-<style scoped>
-@keyframes float {
-  0%, 100% { transform: translateY(0px); }
-  50% { transform: translateY(-10px); }
-}
-.animate-float {
-  animation: float 3s ease-in-out infinite;
-}
-@media (prefers-reduced-motion: reduce) {
-  .animate-float {
-    animation: none;
-  }
-}
-</style>

--- a/src/components/ServiceOverviewSection.vue
+++ b/src/components/ServiceOverviewSection.vue
@@ -5,46 +5,57 @@
         <div class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">服务总览</div>
         <h2 class="mt-2 text-2xl font-bold text-gray-900">5 类合作 & 报价对比</h2>
       </div>
-      <div class="inline-flex items-center rounded-full bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700">
-        报价为参考区间，最终以合作方案为准
+      <div class="inline-flex items-center rounded-full bg-amber-50 border border-amber-200 px-4 py-2 text-xs md:text-sm font-medium text-amber-800">
+        报价口径混合（单篇 / 单价 / 月费 / 分佣），起步预算见各行
       </div>
     </div>
     <p class="mt-4 max-w-4xl text-sm leading-7 text-gray-600">
-      按合作目标快速选型：要曝光走推文，要可量化点击走引流，要长期私域走社群；要持续内容资产 + 高提成转化，看 AI Access / 出海云访问 两个专题。各服务可单选，也可组合执行。点击「专项介绍」查看完整说明，「查看案例」浏览合作呈现方式。
+      按合作目标快速选型：要曝光走推文，要可量化点击走引流，要长期私域走社群；要持续内容资产 + 高提成转化，看 AI Access / 出海云访问 两个联运专题。各服务可单选，也可组合执行。点击「专项介绍」查看完整说明，「查看案例」浏览合作呈现方式。
     </p>
 
-    <div class="mt-6 overflow-x-auto rounded-xl border border-slate-200 bg-white">
+    <!-- Desktop table (md+) -->
+    <div class="mt-6 hidden md:block overflow-x-auto rounded-xl border border-slate-200 bg-white">
       <table class="min-w-full divide-y divide-slate-200 text-left text-sm">
         <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
           <tr>
             <th class="px-4 py-3 font-semibold whitespace-nowrap">服务</th>
-            <th class="px-4 py-3 font-semibold whitespace-nowrap">类型</th>
+            <th class="px-4 py-3 font-semibold whitespace-nowrap">合作模式</th>
             <th class="px-4 py-3 font-semibold">适合场景</th>
-            <th class="px-4 py-3 font-semibold whitespace-nowrap">参考报价</th>
-            <th class="px-4 py-3 font-semibold">主要效果</th>
-            <th class="px-4 py-3 font-semibold whitespace-nowrap">周期</th>
+            <th class="px-4 py-3 font-semibold whitespace-nowrap">报价 & 起步</th>
+            <th class="px-4 py-3 font-semibold">核心指标 / 资产</th>
+            <th class="px-4 py-3 font-semibold whitespace-nowrap">起投周期</th>
             <th class="px-4 py-3 font-semibold whitespace-nowrap">专项介绍</th>
             <th class="px-4 py-3 font-semibold whitespace-nowrap">案例参考</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-slate-200">
+          <!-- 推文 -->
           <tr class="hover:bg-slate-50/60">
             <td class="px-4 py-4 align-top">
-              <span class="inline-flex items-center gap-2 font-semibold whitespace-nowrap text-gray-900">
+              <div class="inline-flex items-center gap-2 font-semibold whitespace-nowrap text-gray-900">
                 <span>✍️</span><span>推文服务</span>
-              </span>
+              </div>
+              <div class="mt-1 text-xs text-gray-500 whitespace-nowrap">最多 20 位博主 · 多平台同发</div>
             </td>
             <td class="px-4 py-4 align-top">
-              <span class="inline-flex items-center justify-center min-w-[60px] rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">常规</span>
+              <span class="inline-flex items-center justify-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 whitespace-nowrap">单次交付</span>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">想要快速曝光、内容种草和品牌心智</td>
             <td class="px-4 py-4 align-top text-gray-700">
-              <div>直发 ¥500–3k／篇／次（多平台辐射）</div>
-              <div>测评 ¥1.5k–8k／篇／次（多平台辐射）</div>
-              <div>深度测评 ¥5k–3w／篇／次（多平台辐射）</div>
+              <div>想要快速曝光、内容种草和品牌心智</div>
+              <div class="mt-1 text-xs text-gray-500">单次最多调动 20 位博主，掘金 / 知乎 / 小红书 / 公众号 / X 等多平台同时分发</div>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">阅读量、关注转化、品牌可信度</td>
-            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">单次 / 排期</td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div class="font-semibold text-gray-900">起步 ¥500 / 篇</div>
+              <div class="mt-1">直发 ¥500–3k／篇</div>
+              <div>测评 ¥1.5k–8k／篇</div>
+              <div>深度测评 ¥5k–3w／篇</div>
+              <div class="mt-1 text-xs text-gray-500">按博主层级 / 粉丝量浮动</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div>阅读量、关注转化、品牌可信度</div>
+              <div class="mt-1 text-xs text-gray-500">沉淀：原帖链接 + 平台权重</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">单篇起 / 可排期</td>
             <td class="px-4 py-4 align-top">
               <router-link to="/tob/services/tweet" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">专项介绍</router-link>
             </td>
@@ -52,6 +63,8 @@
               <router-link to="/cases/tweet" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">查看案例</router-link>
             </td>
           </tr>
+
+          <!-- 引流 -->
           <tr class="hover:bg-slate-50/60">
             <td class="px-4 py-4 align-top">
               <span class="inline-flex items-center gap-2 font-semibold whitespace-nowrap text-gray-900">
@@ -59,15 +72,19 @@
               </span>
             </td>
             <td class="px-4 py-4 align-top">
-              <span class="inline-flex items-center justify-center min-w-[60px] rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">常规</span>
+              <span class="inline-flex items-center justify-center rounded-full bg-emerald-50 border border-emerald-200 px-3 py-1 text-xs font-medium text-emerald-700 whitespace-nowrap">按效果 · CPC</span>
             </td>
             <td class="px-4 py-4 align-top text-gray-700">想要可量化点击、注册和试用线索</td>
             <td class="px-4 py-4 align-top text-gray-700">
-              <div>CPC ¥1–10／有效点击</div>
-              <div class="text-xs text-gray-500">依品类与结算口径浮动</div>
+              <div class="font-semibold text-gray-900">起步 ¥1 / 有效点击</div>
+              <div class="mt-1">CPC ¥1–10 / 有效点击</div>
+              <div class="mt-1 text-xs text-gray-500">AI / 出海类偏高，国内通用工具偏低；按品类与结算口径浮动</div>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">点击量、注册量、试用线索</td>
-            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">持续可投</td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div>点击量、注册量、试用线索</div>
+              <div class="mt-1 text-xs text-gray-500">沉淀：UTM 追踪数据</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">建议 ≥ 2 周</td>
             <td class="px-4 py-4 align-top">
               <router-link to="/tob/services/cpc" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">专项介绍</router-link>
             </td>
@@ -75,6 +92,8 @@
               <router-link to="/cases/cpc" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">查看案例</router-link>
             </td>
           </tr>
+
+          <!-- 社群 -->
           <tr class="hover:bg-slate-50/60">
             <td class="px-4 py-4 align-top">
               <span class="inline-flex items-center gap-2 font-semibold whitespace-nowrap text-gray-900">
@@ -82,15 +101,20 @@
               </span>
             </td>
             <td class="px-4 py-4 align-top">
-              <span class="inline-flex items-center justify-center min-w-[60px] rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">常规</span>
+              <span class="inline-flex items-center justify-center rounded-full bg-blue-50 border border-blue-200 px-3 py-1 text-xs font-medium text-blue-700 whitespace-nowrap">月度运营</span>
             </td>
             <td class="px-4 py-4 align-top text-gray-700">想要长期私域沉淀和稳定开发者关系</td>
             <td class="px-4 py-4 align-top text-gray-700">
-              <div>社群宣发 ¥2k–1w／月</div>
+              <div class="font-semibold text-gray-900">起步 ¥2k / 月</div>
+              <div class="mt-1">社群宣发 ¥2k–1w／月</div>
               <div>建群项目 ¥3k–3w</div>
+              <div class="mt-1 text-xs text-gray-500">按社群规模、活跃节奏与运营深度浮动</div>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">入群人数、活跃度、长期触达资产</td>
-            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">月度 / 项目制</td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div>入群人数、活跃度、长期触达资产</div>
+              <div class="mt-1 text-xs text-gray-500">沉淀：专属社群 / 私域用户池</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">月度起 · 建群 ≥ 1 月</td>
             <td class="px-4 py-4 align-top">
               <router-link to="/tob/services/community" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">专项介绍</router-link>
             </td>
@@ -98,6 +122,18 @@
               <router-link to="/cases/community" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">查看案例</router-link>
             </td>
           </tr>
+
+          <!-- 分组分隔行：长期联运专题 -->
+          <tr class="bg-amber-50/40">
+            <td colspan="8" class="px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-amber-800">
+              <span class="inline-flex items-center gap-2">
+                <span class="inline-block h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+                以下为长期联运专题 · 由联盟方搭建内容 / 站点 / 仓库 / 社群资产，按成交分佣
+              </span>
+            </td>
+          </tr>
+
+          <!-- AI Access -->
           <tr class="hover:bg-slate-50/60">
             <td class="px-4 py-4 align-top">
               <span class="inline-flex items-center gap-2 font-semibold whitespace-nowrap text-gray-900">
@@ -105,15 +141,22 @@
               </span>
             </td>
             <td class="px-4 py-4 align-top">
-              <span class="inline-flex items-center justify-center min-w-[60px] rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">专题</span>
+              <span class="inline-flex items-center justify-center rounded-full bg-amber-100 border border-amber-200 px-3 py-1 text-xs font-medium text-amber-800 whitespace-nowrap">联运分佣</span>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">海外大模型 / AI 工具使用需求承接</td>
             <td class="px-4 py-4 align-top text-gray-700">
-              <div>高提成分佣</div>
-              <div class="text-xs text-gray-500">参考 30%–60%，按成交结算</div>
+              <div>境外大模型 / AI SaaS 订阅承接</div>
+              <div class="mt-1 text-xs text-gray-500">聚焦 ChatGPT / Claude 等订阅类工具</div>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">站点 / 仓库 / 社群资产 + 长期转化</td>
-            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">长期合作</td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div class="font-semibold text-gray-900">零硬投入 · 按成交分佣</div>
+              <div class="mt-1">参考 30%–60% / 笔</div>
+              <div class="mt-1 text-xs text-gray-500">按品类、客单价、复购周期浮动</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div>高 LTV 长期转化</div>
+              <div class="mt-1 text-xs text-gray-500">沉淀：AI 站点矩阵 + 仓库 SEO + 社群</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">建议 ≥ 3 个月</td>
             <td class="px-4 py-4 align-top">
               <router-link to="/tob/services/ai-access" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">专项介绍</router-link>
             </td>
@@ -121,6 +164,8 @@
               <router-link to="/cases/ai-access" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">查看案例</router-link>
             </td>
           </tr>
+
+          <!-- 出海云访问 -->
           <tr class="hover:bg-slate-50/60">
             <td class="px-4 py-4 align-top">
               <span class="inline-flex items-center gap-2 font-semibold whitespace-nowrap text-gray-900">
@@ -128,15 +173,22 @@
               </span>
             </td>
             <td class="px-4 py-4 align-top">
-              <span class="inline-flex items-center justify-center min-w-[60px] rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">专题</span>
+              <span class="inline-flex items-center justify-center rounded-full bg-amber-100 border border-amber-200 px-3 py-1 text-xs font-medium text-amber-800 whitespace-nowrap">联运分佣</span>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">出海云访问 / 跨境办公工具推广</td>
             <td class="px-4 py-4 align-top text-gray-700">
-              <div>高提成分佣</div>
-              <div class="text-xs text-gray-500">参考 30%–60%，按成交结算</div>
+              <div>云服务 / 节点 / 跨境办公出海推广</div>
+              <div class="mt-1 text-xs text-gray-500">聚焦真实节点测速 + 出海团队场景教程</div>
             </td>
-            <td class="px-4 py-4 align-top text-gray-700">站点 / 导航 / 社群资产 + 长期转化</td>
-            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">长期合作</td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div class="font-semibold text-gray-900">零硬投入 · 按成交分佣</div>
+              <div class="mt-1">参考 30%–60% / 笔</div>
+              <div class="mt-1 text-xs text-gray-500">仅承接合规面向出海 / 跨境场景</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <div>高 LTV 长期转化</div>
+              <div class="mt-1 text-xs text-gray-500">沉淀：教程站 + 对比导航 + 出海社群</div>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700 whitespace-nowrap">建议 ≥ 3 个月</td>
             <td class="px-4 py-4 align-top">
               <router-link to="/tob/services/oversea-cloud" class="font-medium text-indigo-700 hover:underline whitespace-nowrap">专项介绍</router-link>
             </td>
@@ -148,15 +200,86 @@
       </table>
     </div>
 
-    <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-gray-600">
-      <div class="rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2">
-        <span class="font-semibold text-slate-700">怎么选：</span>一次性发声 → 推文；持续要点击/线索 → 引流；想要长期沉淀 → 社群。
+    <!-- Mobile cards (below md) -->
+    <div class="mt-6 md:hidden space-y-3">
+      <div
+        v-for="row in mobileRows"
+        :key="row.title"
+        class="rounded-xl border border-slate-200 bg-white p-4"
+        :class="row.theme === 'special' ? 'border-amber-200 bg-amber-50/30' : ''"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <div class="inline-flex items-center gap-2 font-semibold text-gray-900">
+              <span>{{ row.icon }}</span><span>{{ row.title }}</span>
+            </div>
+            <div v-if="row.subtitle" class="mt-0.5 text-xs text-gray-500">{{ row.subtitle }}</div>
+          </div>
+          <span
+            class="inline-flex items-center justify-center rounded-full px-2.5 py-1 text-[11px] font-medium whitespace-nowrap"
+            :class="row.modeClass"
+          >{{ row.mode }}</span>
+        </div>
+        <div class="mt-2 text-sm text-gray-700">{{ row.scene }}</div>
+        <div v-if="row.sceneNote" class="text-xs text-gray-500">{{ row.sceneNote }}</div>
+
+        <div class="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+          <div>
+            <div class="text-gray-500">起步</div>
+            <div class="mt-0.5 font-semibold text-gray-900">{{ row.startsAt }}</div>
+          </div>
+          <div>
+            <div class="text-gray-500">起投周期</div>
+            <div class="mt-0.5 text-gray-800">{{ row.cycle }}</div>
+          </div>
+        </div>
+
+        <div class="mt-3 text-xs text-gray-700">
+          <div class="text-gray-500">报价范围</div>
+          <div v-for="line in row.priceLines" :key="line" class="mt-0.5">{{ line }}</div>
+          <div v-if="row.priceNote" class="mt-1 text-gray-500">{{ row.priceNote }}</div>
+        </div>
+
+        <div class="mt-3 text-xs text-gray-700">
+          <div class="text-gray-500">核心指标 / 资产</div>
+          <div class="mt-0.5">{{ row.metrics }}</div>
+          <div v-if="row.asset" class="mt-0.5 text-gray-500">沉淀：{{ row.asset }}</div>
+        </div>
+
+        <div class="mt-4 flex flex-wrap gap-3 text-sm">
+          <router-link :to="row.detailTo" class="font-medium text-indigo-700 hover:underline">专项介绍 →</router-link>
+          <router-link :to="row.caseTo" class="font-medium text-indigo-700 hover:underline">查看案例 →</router-link>
+        </div>
       </div>
-      <div class="rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2">
-        <span class="font-semibold text-slate-700">可组合：</span>推文 + 引流追加 UTM 追踪、社群宣发承接专题流量都常见。
+    </div>
+
+    <!-- Decision helper -->
+    <div class="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-gray-600">
+      <div class="rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2.5">
+        <div class="font-semibold text-slate-700 mb-1">按目标选</div>
+        一次性发声 → 推文；持续要点击 / 线索 → 引流；长期沉淀 → 社群；长期高提成 → 专题联运。
       </div>
-      <div class="rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2">
-        <span class="font-semibold text-slate-700">专题优势：</span>由我们承担内容、站点、仓库与社群搭建，按成交分佣，零硬性投放预算。
+      <div class="rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2.5">
+        <div class="font-semibold text-slate-700 mb-1">按预算选</div>
+        零硬投入 → 专题分佣；月度可控 → 社群 / CPC；单次预算 → 推文。推文 + 引流可叠加 UTM 追踪。
+      </div>
+      <div class="rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2.5">
+        <div class="font-semibold text-slate-700 mb-1">按周期选</div>
+        单篇 / 排期 → 推文；2 周到几个月 → 引流 / 社群；3 个月以上长期协同 → 专题联运。
+      </div>
+    </div>
+
+    <!-- Primary CTA -->
+    <div class="mt-5 rounded-xl border border-indigo-100 bg-gradient-to-r from-indigo-50 to-violet-50 p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div class="text-sm leading-7 text-gray-700">
+        <span class="font-semibold text-gray-900">选好了想直接询价？</span>
+        右下角浮动「我要合作」扫码加微信
+        <span class="font-mono text-indigo-700">atar24</span>
+        ，备注预算 / 品类 / 目标，1 个工作日内给方案。
+      </div>
+      <div class="flex flex-wrap gap-2 shrink-0">
+        <router-link to="/cases" class="inline-flex items-center justify-center rounded-full bg-white border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50">先看案例</router-link>
+        <router-link to="/tob/services" class="inline-flex items-center justify-center rounded-full bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700">服务总入口 →</router-link>
       </div>
     </div>
   </section>
@@ -169,4 +292,105 @@ defineProps({
     default: 'overview'
   }
 })
+
+const modeClassMap = {
+  regular: 'bg-slate-100 text-slate-700',
+  effect: 'bg-emerald-50 border border-emerald-200 text-emerald-700',
+  monthly: 'bg-blue-50 border border-blue-200 text-blue-700',
+  affiliate: 'bg-amber-100 border border-amber-200 text-amber-800'
+}
+
+const mobileRows = [
+  {
+    icon: '✍️',
+    title: '推文服务',
+    subtitle: '最多 20 位博主 · 多平台同发',
+    mode: '单次交付',
+    modeClass: modeClassMap.regular,
+    theme: 'regular',
+    scene: '想要快速曝光、内容种草和品牌心智',
+    sceneNote: '单次最多调动 20 位博主，掘金 / 知乎 / 小红书 / 公众号 / X 等多平台同时分发',
+    startsAt: '¥500 / 篇',
+    cycle: '单篇起 / 可排期',
+    priceLines: [
+      '直发 ¥500–3k／篇',
+      '测评 ¥1.5k–8k／篇',
+      '深度测评 ¥5k–3w／篇'
+    ],
+    priceNote: '按博主层级 / 粉丝量浮动',
+    metrics: '阅读量、关注转化、品牌可信度',
+    asset: '原帖链接 + 平台权重',
+    detailTo: '/tob/services/tweet',
+    caseTo: '/cases/tweet'
+  },
+  {
+    icon: '🔗',
+    title: '引流服务',
+    mode: '按效果 · CPC',
+    modeClass: modeClassMap.effect,
+    theme: 'regular',
+    scene: '想要可量化点击、注册和试用线索',
+    startsAt: '¥1 / 有效点击',
+    cycle: '建议 ≥ 2 周',
+    priceLines: ['CPC ¥1–10 / 有效点击'],
+    priceNote: 'AI / 出海类偏高，国内通用工具偏低；按品类与结算口径浮动',
+    metrics: '点击量、注册量、试用线索',
+    asset: 'UTM 追踪数据',
+    detailTo: '/tob/services/cpc',
+    caseTo: '/cases/cpc'
+  },
+  {
+    icon: '👥',
+    title: '社群服务',
+    mode: '月度运营',
+    modeClass: modeClassMap.monthly,
+    theme: 'regular',
+    scene: '想要长期私域沉淀和稳定开发者关系',
+    startsAt: '¥2k / 月',
+    cycle: '月度起 · 建群 ≥ 1 月',
+    priceLines: [
+      '社群宣发 ¥2k–1w／月',
+      '建群项目 ¥3k–3w'
+    ],
+    priceNote: '按社群规模、活跃节奏与运营深度浮动',
+    metrics: '入群人数、活跃度、长期触达资产',
+    asset: '专属社群 / 私域用户池',
+    detailTo: '/tob/services/community',
+    caseTo: '/cases/community'
+  },
+  {
+    icon: '🤖',
+    title: 'AI Access',
+    mode: '联运分佣',
+    modeClass: modeClassMap.affiliate,
+    theme: 'special',
+    scene: '境外大模型 / AI SaaS 订阅承接',
+    sceneNote: '聚焦 ChatGPT / Claude 等订阅类工具',
+    startsAt: '零硬投入',
+    cycle: '建议 ≥ 3 个月',
+    priceLines: ['分佣 30%–60% / 笔', '按成交结算'],
+    priceNote: '按品类、客单价、复购周期浮动',
+    metrics: '高 LTV 长期转化',
+    asset: 'AI 站点矩阵 + 仓库 SEO + 社群',
+    detailTo: '/tob/services/ai-access',
+    caseTo: '/cases/ai-access'
+  },
+  {
+    icon: '🌐',
+    title: '出海云访问',
+    mode: '联运分佣',
+    modeClass: modeClassMap.affiliate,
+    theme: 'special',
+    scene: '云服务 / 节点 / 跨境办公出海推广',
+    sceneNote: '聚焦真实节点测速 + 出海团队场景教程',
+    startsAt: '零硬投入',
+    cycle: '建议 ≥ 3 个月',
+    priceLines: ['分佣 30%–60% / 笔', '按成交结算'],
+    priceNote: '仅承接合规面向出海 / 跨境场景',
+    metrics: '高 LTV 长期转化',
+    asset: '教程站 + 对比导航 + 出海社群',
+    detailTo: '/tob/services/oversea-cloud',
+    caseTo: '/cases/oversea-cloud'
+  }
+]
 </script>

--- a/src/pages/tob/index.vue
+++ b/src/pages/tob/index.vue
@@ -1,138 +1,248 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50">
+  <div class="min-h-screen bg-gradient-to-b from-indigo-50/50 via-white to-white">
     <AppNav logo-to="/" />
 
     <!-- Hero 区域 -->
     <section class="relative overflow-hidden">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-16 lg:pt-14 lg:pb-24">
+      <!-- subtle decorative blobs -->
+      <div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+        <div class="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-200/30 blur-3xl"></div>
+        <div class="absolute -top-10 right-0 h-80 w-80 rounded-full bg-violet-200/25 blur-3xl"></div>
+        <div class="absolute top-60 left-1/3 h-60 w-60 rounded-full bg-sky-200/20 blur-3xl"></div>
+      </div>
+
+      <div class="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-14 pb-14 lg:pt-20 lg:pb-20">
         <div class="text-center">
-          <h1 class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
-            <span class="block mb-6">博主联盟</span>
-            <span class="relative inline-block">
-              <span class="block text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 to-purple-600">
-                连接 AI 产品与技术影响力
-              </span>
-            </span>
+          <h1 class="text-4xl md:text-6xl font-bold text-slate-900 tracking-tight leading-tight">
+            博主联盟
           </h1>
-          <p class="text-lg md:text-xl text-gray-600 max-w-4xl mx-auto leading-relaxed mb-8">
-            我们聚合一批专业技术博主，把技术品牌带到开发者 / AI 爱好者 / 科技爱好者真正会讨论的地方，并持续沉淀真实有效的 GEO 结果
+          <p class="mt-5 max-w-5xl mx-auto text-3xl md:text-5xl font-bold tracking-tight leading-tight bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
+            连接 AI 产品与技术影响力
+          </p>
+          <p class="mt-6 max-w-3xl mx-auto text-base md:text-lg text-slate-600 leading-relaxed">
+            我们聚合一批专业技术博主，把技术品牌带到开发者 / AI 爱好者 / 科技爱好者真正会讨论的地方，并持续沉淀真实有效的 GEO 结果。
           </p>
 
-          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-5 sm:gap-6 max-w-6xl mx-auto">
-            <div class="text-center">
-              <div class="text-3xl font-bold text-indigo-600 mb-2">{{ bloggerStats.bloggerCount }} 位+</div>
-              <div class="text-gray-600">技术博主</div>
-            </div>
-            <div class="text-center">
-              <div class="text-3xl font-bold text-purple-600 mb-2">{{ bloggerStats.formattedFollowers }}+</div>
-              <div class="text-gray-600">覆盖程序员 / 科技粉丝</div>
-            </div>
-            <div class="text-center">
-              <div class="text-3xl font-bold text-green-600 mb-2">{{ bloggerStats.totalPosts }} 篇+</div>
-              <div class="text-gray-600">累计投放推文</div>
-            </div>
-            <div class="text-center">
-              <div class="text-3xl font-bold text-rose-600 mb-2">{{ bloggerStats.formattedExposure }}+</div>
-              <div class="text-gray-600">累计曝光</div>
-            </div>
-            <div class="text-center">
-              <div class="text-3xl font-bold text-orange-600 mb-2">20 个+</div>
-              <div class="text-gray-600">辐射社群</div>
+          <!-- Feature chips -->
+          <div class="mt-6 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-xs md:text-sm text-slate-600">
+            <span class="inline-flex items-center gap-1.5"><span class="h-1.5 w-1.5 rounded-full bg-indigo-500"></span>5 类合作可组合</span>
+            <span class="text-slate-300">/</span>
+            <span class="inline-flex items-center gap-1.5"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>单次最多 20 位博主</span>
+            <span class="text-slate-300">/</span>
+            <span class="inline-flex items-center gap-1.5"><span class="h-1.5 w-1.5 rounded-full bg-violet-500"></span>高提成专题分佣</span>
+            <span class="text-slate-300">/</span>
+            <span class="inline-flex items-center gap-1.5"><span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>1 工作日响应</span>
+          </div>
+
+          <!-- Primary CTAs -->
+          <div class="mt-9 flex flex-wrap items-center justify-center gap-3">
+            <a
+              href="#service-overview"
+              class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-600 to-violet-600 px-6 py-3 text-sm font-medium text-white shadow-lg shadow-indigo-200/60 hover:shadow-xl hover:shadow-indigo-200 hover:from-indigo-700 hover:to-violet-700 transition-all"
+            >
+              查看服务与报价
+              <span aria-hidden="true">→</span>
+            </a>
+            <router-link
+              to="/cases"
+              class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white/80 backdrop-blur px-6 py-3 text-sm font-medium text-slate-700 hover:border-indigo-300 hover:text-indigo-700 transition-colors"
+            >
+              浏览合作案例
+            </router-link>
+            <a
+              href="#positioning"
+              class="inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-900 underline-offset-4 hover:underline"
+            >
+              生态定位 & 我们的优势 ↓
+            </a>
+          </div>
+
+          <!-- Stats strip -->
+          <div class="mt-14 mx-auto max-w-5xl">
+            <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-x-4 gap-y-8">
+              <div class="text-center">
+                <div class="text-3xl md:text-4xl font-bold text-indigo-600 tabular-nums">{{ bloggerStats.bloggerCount }} 位+</div>
+                <div class="mt-2 text-sm text-slate-600">技术博主</div>
+              </div>
+              <div class="text-center">
+                <div class="text-3xl md:text-4xl font-bold text-purple-600 tabular-nums">{{ bloggerStats.formattedFollowers }}+</div>
+                <div class="mt-2 text-sm text-slate-600">覆盖程序员 / 科技粉丝</div>
+              </div>
+              <div class="text-center">
+                <div class="text-3xl md:text-4xl font-bold text-green-600 tabular-nums">{{ bloggerStats.totalPosts }} 篇+</div>
+                <div class="mt-2 text-sm text-slate-600">累计投放推文</div>
+              </div>
+              <div class="text-center">
+                <div class="text-3xl md:text-4xl font-bold text-rose-600 tabular-nums">{{ bloggerStats.formattedExposure }}+</div>
+                <div class="mt-2 text-sm text-slate-600">累计曝光</div>
+              </div>
+              <div class="text-center col-span-2 sm:col-span-1">
+                <div class="text-3xl md:text-4xl font-bold text-orange-600 tabular-nums">20 个+</div>
+                <div class="mt-2 text-sm text-slate-600">辐射社群</div>
+              </div>
             </div>
           </div>
 
-          <nav
-            class="mx-auto mt-10 max-w-5xl rounded-xl border border-slate-200/70 bg-white/50 px-4 py-4 sm:px-6 backdrop-blur-sm"
-            aria-label="站内导航"
-          >
-            <div class="grid gap-5 sm:gap-6 md:grid-cols-2 md:gap-0">
-              <div class="border-b border-slate-200/70 pb-5 text-center md:border-b-0 md:pb-0 md:text-left md:pr-6 md:border-r md:border-slate-200/70">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-indigo-700/85 mb-2.5 md:mb-3">
-                  合作入口
-                </p>
-                <ul class="flex flex-wrap items-center justify-center gap-x-1 gap-y-2 md:justify-start text-sm sm:text-[15px]">
-                  <li>
-                    <a
-                      href="#service-overview"
-                      class="group inline-flex items-center gap-1.5 py-1 font-medium text-slate-600 transition-colors hover:text-indigo-700"
-                    >
-                      <span class="text-base leading-none opacity-90 select-none" aria-hidden="true">📋</span>
-                      <span class="underline-offset-4 decoration-indigo-200/80 group-hover:underline">服务与参考报价</span>
-                    </a>
-                  </li>
-                  <li class="hidden sm:flex items-center px-2 text-slate-300 select-none" aria-hidden="true">·</li>
-                  <li>
-                    <router-link
-                      to="/cases"
-                      class="group inline-flex items-center gap-1.5 py-1 font-medium text-slate-600 transition-colors hover:text-indigo-700"
-                    >
-                      <span class="text-base leading-none opacity-90 select-none" aria-hidden="true">📘</span>
-                      <span class="underline-offset-4 decoration-indigo-200/80 group-hover:underline">案例介绍</span>
-                    </router-link>
-                  </li>
-                  <li class="hidden sm:flex items-center px-2 text-slate-300 select-none" aria-hidden="true">·</li>
-                  <li>
-                    <a
-                      href="#blogger-team"
-                      class="group inline-flex items-center gap-1.5 py-1 font-medium text-slate-600 transition-colors hover:text-indigo-700"
-                    >
-                      <span class="text-base leading-none opacity-90 select-none" aria-hidden="true">👥</span>
-                      <span class="underline-offset-4 decoration-indigo-200/80 group-hover:underline">博主矩阵</span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-              <div class="text-center md:text-left md:pl-6">
-                <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 mb-2.5 md:mb-3">
-                  关于博主联盟
-                </p>
-                <ul class="flex flex-wrap items-center justify-center gap-x-1 gap-y-2 md:justify-start text-sm sm:text-[15px]">
-                  <li>
-                    <router-link
-                      to="/ecosystem"
-                      class="group inline-flex items-center gap-1.5 py-1 font-medium text-slate-600 transition-colors hover:text-indigo-700"
-                    >
-                      <span class="text-base leading-none select-none" aria-hidden="true">📍</span>
-                      <span class="underline-offset-4 decoration-indigo-200/80 group-hover:underline">生态定位</span>
-                    </router-link>
-                  </li>
-                  <li class="hidden sm:flex items-center px-2 text-slate-300 select-none" aria-hidden="true">·</li>
-                  <li>
-                    <router-link
-                      to="/why-us"
-                      class="group inline-flex items-center gap-1.5 py-1 font-medium text-slate-600 transition-colors hover:text-indigo-700"
-                    >
-                      <span class="text-base leading-none select-none" aria-hidden="true">✨</span>
-                      <span class="text-left underline-offset-4 decoration-indigo-200/80 group-hover:underline">为什么选择博主联盟？</span>
-                    </router-link>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </nav>
-
-          <div class="mt-12 max-w-4xl mx-auto">
-            <h3 class="mb-4 text-center text-sm md:text-base font-semibold text-gray-600">已合作品牌</h3>
+          <div class="mt-16 max-w-4xl mx-auto">
+            <div class="mb-5 text-center text-[11px] font-medium uppercase tracking-[0.24em] text-slate-400">已合作品牌</div>
             <BrandMarquee />
           </div>
         </div>
       </div>
+    </section>
 
-      <div class="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none">
-        <div class="absolute top-20 left-10 w-20 h-20 bg-indigo-200 rounded-full opacity-20 animate-pulse"></div>
-        <div class="absolute top-40 right-20 w-16 h-16 bg-purple-200 rounded-full opacity-20 animate-pulse delay-1000"></div>
-        <div class="absolute bottom-20 left-20 w-12 h-12 bg-blue-200 rounded-full opacity-20 animate-pulse delay-2000"></div>
+    <!-- 定位 & 优势 -->
+    <section id="positioning" class="relative scroll-mt-24">
+      <div class="absolute inset-0 bg-gradient-to-b from-slate-50/80 via-indigo-50/30 to-white pointer-events-none"></div>
+      <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+        <div class="text-center mb-14">
+          <div class="text-xs font-medium uppercase tracking-[0.24em] text-indigo-600">Position & Edge</div>
+          <h2 class="mt-3 text-3xl md:text-4xl font-light text-slate-900 tracking-tight">我们站在哪里 · 凭什么相信</h2>
+          <p class="mt-4 max-w-2xl mx-auto text-base text-slate-500 leading-relaxed">
+            在 AI 生态的传播链路里有清晰位置，并把这条路径上的能力做厚。
+          </p>
+        </div>
+
+        <div class="grid gap-6 lg:grid-cols-12">
+          <!-- 生态定位 (5 cols) -->
+          <div class="lg:col-span-5">
+            <div class="h-full rounded-2xl border border-indigo-100 bg-gradient-to-br from-white to-indigo-50/60 p-7 shadow-sm">
+              <div class="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.22em] text-indigo-600">
+                <span aria-hidden="true">📍</span>
+                Our Position
+              </div>
+              <div class="mt-3 text-xl font-semibold text-slate-900">AI 生态中的「开发者传播渠道」</div>
+              <p class="mt-3 text-sm leading-7 text-slate-600">
+                上游有算力与模型，中游有产品与工具，下游是真实用户与商单。我们是中间这条把产品讲给开发者、并形成市场教育的渠道层。
+              </p>
+
+              <!-- 4 layers visual -->
+              <div class="mt-5 space-y-2">
+                <div class="flex items-center gap-3 rounded-lg border border-slate-200 bg-white/80 px-3 py-2.5">
+                  <span class="text-[10px] font-mono text-slate-400 w-8">L1</span>
+                  <span class="text-sm font-medium text-slate-700">上游 · 基础能力层</span>
+                  <span class="ml-auto text-xs text-slate-400">算力 · 模型 · 框架</span>
+                </div>
+                <div class="flex items-center gap-3 rounded-lg border border-slate-200 bg-white/80 px-3 py-2.5">
+                  <span class="text-[10px] font-mono text-slate-400 w-8">L2</span>
+                  <span class="text-sm font-medium text-slate-700">中游 · 产品工具层</span>
+                  <span class="ml-auto text-xs text-slate-400">SaaS · 工作流 · API</span>
+                </div>
+                <div class="flex items-center gap-3 rounded-xl border-2 border-indigo-500 bg-gradient-to-r from-indigo-50 to-violet-50 px-3 py-3 shadow-sm">
+                  <span class="text-[10px] font-mono text-indigo-600 w-8 font-semibold">L3</span>
+                  <span class="text-sm font-semibold text-slate-900">渠道 · 开发者传播</span>
+                  <span class="ml-auto inline-flex items-center gap-1 text-xs font-medium text-indigo-700">
+                    <span aria-hidden="true">←</span> 我们在这
+                  </span>
+                </div>
+                <div class="flex items-center gap-3 rounded-lg border border-slate-200 bg-white/80 px-3 py-2.5">
+                  <span class="text-[10px] font-mono text-slate-400 w-8">L4</span>
+                  <span class="text-sm font-medium text-slate-700">下游 · 用户与商业转化</span>
+                  <span class="ml-auto text-xs text-slate-400">付费 · 复购 · LTV</span>
+                </div>
+              </div>
+
+              <router-link
+                to="/ecosystem"
+                class="mt-5 inline-flex items-center gap-1 text-sm font-medium text-indigo-700 hover:text-indigo-900 underline-offset-4 hover:underline"
+              >
+                查看完整生态定位
+                <span aria-hidden="true">→</span>
+              </router-link>
+            </div>
+          </div>
+
+          <!-- 4 优势 (7 cols) -->
+          <div class="lg:col-span-7">
+            <div class="text-xs font-medium uppercase tracking-[0.22em] text-violet-600 mb-3">
+              <span aria-hidden="true">✨</span> Why Us · 四项核心能力
+            </div>
+            <div class="grid sm:grid-cols-2 gap-4">
+              <!-- 优势 1 -->
+              <div class="group rounded-2xl border border-slate-200 bg-white p-6 hover:border-indigo-300 hover:shadow-md transition-all">
+                <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-indigo-50 text-indigo-600 text-lg">
+                  <span aria-hidden="true">📝</span>
+                </div>
+                <div class="mt-4 text-base font-semibold text-slate-900">技术内容生产力</div>
+                <p class="mt-2 text-sm leading-6 text-slate-600">
+                  能把产品讲成技术文章，覆盖痛点 / 接入 / Benchmark 全套结构，不是硬广。
+                </p>
+                <div class="mt-3 flex flex-wrap gap-1.5 text-[11px]">
+                  <span class="rounded-md bg-indigo-50 text-indigo-700 px-2 py-0.5">技术理解</span>
+                  <span class="rounded-md bg-indigo-50 text-indigo-700 px-2 py-0.5">写作能力</span>
+                  <span class="rounded-md bg-indigo-50 text-indigo-700 px-2 py-0.5">产品视角</span>
+                </div>
+              </div>
+
+              <!-- 优势 2 -->
+              <div class="group rounded-2xl border border-slate-200 bg-white p-6 hover:border-emerald-300 hover:shadow-md transition-all">
+                <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-emerald-50 text-emerald-600 text-lg">
+                  <span aria-hidden="true">🧑‍💻</span>
+                </div>
+                <div class="mt-4 text-base font-semibold text-slate-900">开发者真实在场</div>
+                <p class="mt-2 text-sm leading-6 text-slate-600">
+                  41 位长期活跃的技术博主 + 20 个开发者社群，覆盖掘金 / 知乎 / 小红书 / 公众号 / X 等讨论场。
+                </p>
+                <div class="mt-3 flex flex-wrap gap-1.5 text-[11px]">
+                  <span class="rounded-md bg-emerald-50 text-emerald-700 px-2 py-0.5">5+ 主流平台</span>
+                  <span class="rounded-md bg-emerald-50 text-emerald-700 px-2 py-0.5">20+ 开发者社群</span>
+                  <span class="rounded-md bg-emerald-50 text-emerald-700 px-2 py-0.5">技术圈语境</span>
+                </div>
+              </div>
+
+              <!-- 优势 3 -->
+              <div class="group rounded-2xl border border-slate-200 bg-white p-6 hover:border-violet-300 hover:shadow-md transition-all">
+                <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-violet-50 text-violet-600 text-lg">
+                  <span aria-hidden="true">🔍</span>
+                </div>
+                <div class="mt-4 text-base font-semibold text-slate-900">GEO 长期可见度沉淀</div>
+                <p class="mt-2 text-sm leading-6 text-slate-600">
+                  每篇内容在搜索 / AI 问答里都是一次长尾占位，把品牌沉淀进 AI 时代的可见度池。
+                </p>
+                <div class="mt-3 flex flex-wrap gap-1.5 text-[11px]">
+                  <span class="rounded-md bg-violet-50 text-violet-700 px-2 py-0.5">长尾搜索</span>
+                  <span class="rounded-md bg-violet-50 text-violet-700 px-2 py-0.5">品牌占位</span>
+                  <span class="rounded-md bg-violet-50 text-violet-700 px-2 py-0.5">AI 问答触达</span>
+                </div>
+              </div>
+
+              <!-- 优势 4 -->
+              <div class="group rounded-2xl border border-slate-200 bg-white p-6 hover:border-amber-300 hover:shadow-md transition-all">
+                <div class="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-amber-50 text-amber-700 text-lg">
+                  <span aria-hidden="true">🤝</span>
+                </div>
+                <div class="mt-4 text-base font-semibold text-slate-900">流程清晰可履约</div>
+                <p class="mt-2 text-sm leading-6 text-slate-600">
+                  从需求确认 → 博主撮合 → 发稿 → 数据回收 → 结算闭环，全流程透明，5+ 年商单履约经验。
+                </p>
+                <div class="mt-3 flex flex-wrap gap-1.5 text-[11px]">
+                  <span class="rounded-md bg-amber-50 text-amber-800 px-2 py-0.5">需求撮合</span>
+                  <span class="rounded-md bg-amber-50 text-amber-800 px-2 py-0.5">数据回收</span>
+                  <span class="rounded-md bg-amber-50 text-amber-800 px-2 py-0.5">结算闭环</span>
+                </div>
+              </div>
+            </div>
+            <router-link
+              to="/why-us"
+              class="mt-4 inline-flex items-center gap-1 text-sm font-medium text-violet-700 hover:text-violet-900 underline-offset-4 hover:underline"
+            >
+              查看 6 层完整优势分析
+              <span aria-hidden="true">→</span>
+            </router-link>
+          </div>
+        </div>
       </div>
     </section>
 
     <!-- 博主团队展示 -->
-    <section id="blogger-team" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-16 scroll-mt-24">
-      <div class="text-center mb-10">
-        <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-6">我们的博主团队名单</h2>
-        <p class="text-xl text-gray-600 max-w-3xl mx-auto">
-          专业的技术博主团队，覆盖前端、后端、AI、移动开发等多个技术领域
-          <a href="#join-cta" class="ml-2 inline-flex items-center gap-1 text-indigo-600 font-medium hover:text-indigo-800 hover:underline underline-offset-4">
-            <span>持续招募中</span>
+    <section id="blogger-team" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 pb-20 scroll-mt-24">
+      <div class="text-center mb-12">
+        <div class="text-xs font-medium uppercase tracking-[0.24em] text-slate-500">Our Bloggers</div>
+        <h2 class="mt-3 text-3xl md:text-4xl font-light text-slate-900 tracking-tight">技术博主矩阵</h2>
+        <p class="mt-4 text-base text-slate-500 max-w-2xl mx-auto leading-relaxed">
+          覆盖前端、后端、AI、移动开发等技术领域。
+          <a href="#join-cta" class="ml-1 inline-flex items-center gap-0.5 text-slate-700 underline underline-offset-4 decoration-slate-300 hover:text-slate-900 hover:decoration-slate-500">
+            持续招募中
             <span aria-hidden="true">↘</span>
           </a>
         </p>
@@ -165,14 +275,15 @@
         />
       </div>
 
-      <div v-if="showGridExpandToggle" class="mt-8 flex justify-center">
+      <div v-if="showGridExpandToggle" class="mt-10 flex justify-center">
         <button
           type="button"
-          class="inline-flex items-center gap-2 rounded-full border border-indigo-200 bg-white px-5 py-2.5 text-sm font-semibold text-indigo-800 shadow-sm transition-colors hover:border-indigo-300 hover:bg-indigo-50"
+          class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-700 transition-colors hover:border-slate-400 hover:text-slate-900"
           @click="bloggersGridExpanded = !bloggersGridExpanded"
         >
           <span v-if="!bloggersGridExpanded">展开全部 {{ filteredAndSortedBloggers.length }} 位博主</span>
-          <span v-else>收起为预览（前 {{ BLOGGER_GRID_PREVIEW }} 位）</span>
+          <span v-else>收起为精选（前 {{ BLOGGER_GRID_PREVIEW }} 位）</span>
+          <span aria-hidden="true" class="text-slate-400">{{ bloggersGridExpanded ? '↑' : '↓' }}</span>
         </button>
       </div>
 
@@ -193,27 +304,73 @@
       <ServiceOverviewSection section-id="service-overview" />
     </div>
 
-    <!-- 底部 CTA -->
-    <section id="join-cta" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <div class="relative overflow-hidden rounded-[28px] border border-amber-200 bg-[linear-gradient(135deg,#fffdf7_0%,#fff7ed_48%,#fffefb_100%)] px-6 py-6 shadow-[0_20px_60px_rgba(120,53,15,0.08)] md:px-8">
-        <div class="absolute right-6 top-5 rotate-6 text-2xl opacity-70">✉️</div>
-        <div class="max-w-3xl">
-          <div class="text-xs font-semibold uppercase tracking-[0.24em] text-amber-700/80">To Builders</div>
-          <div class="mt-2 text-sm font-medium text-amber-800">致程序员 / 技术博主 / 大学生 / AI 爱好者</div>
-          <p class="mt-4 text-sm leading-7 text-gray-700 md:text-base">
-            如果你也想一起共创内容、尝试做 AI 项目、打磨开发者工具，或者用兼职方式参与真实合作，欢迎来和我们聊聊。这里既欢迎长期深度协作，也欢迎从一次内容共创、一次项目尝试开始。
-          </p>
+    <!-- 底部 CTA · 双入口 -->
+    <section id="join-cta" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <div class="text-center mb-10">
+        <div class="text-xs font-medium uppercase tracking-[0.24em] text-indigo-600">Get Started</div>
+        <h2 class="mt-3 text-3xl md:text-4xl font-light text-slate-900 tracking-tight">两个入口，选一个开始</h2>
+      </div>
+      <div class="grid gap-5 md:grid-cols-2 max-w-5xl mx-auto">
+        <!-- 品牌方 -->
+        <div class="group relative overflow-hidden rounded-2xl border border-indigo-200 bg-gradient-to-br from-white via-indigo-50/40 to-violet-50/60 p-7 transition-all hover:shadow-lg hover:shadow-indigo-100">
+          <div class="absolute -top-12 -right-12 h-32 w-32 rounded-full bg-indigo-200/40 blur-2xl pointer-events-none"></div>
+          <div class="relative">
+            <div class="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.22em] text-indigo-700">
+              <span aria-hidden="true">💼</span>
+              For Brands
+            </div>
+            <div class="mt-2 text-xl font-semibold text-slate-900">我是品牌方</div>
+            <p class="mt-3 text-sm leading-7 text-slate-600">
+              想要推文 / 引流 / 社群 / AI 联运。看完表格后想直接询价，加微信 <span class="font-mono text-indigo-700">atar24</span>，备注预算 / 品类 / 目标，1 个工作日内给方案。
+            </p>
+            <div class="mt-6 flex flex-wrap items-center gap-3">
+              <a
+                href="#service-overview"
+                class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-600 to-violet-600 px-5 py-2.5 text-sm font-medium text-white shadow-md shadow-indigo-200 hover:shadow-lg hover:from-indigo-700 hover:to-violet-700 transition-all"
+              >
+                查看服务与报价
+                <span aria-hidden="true">→</span>
+              </a>
+              <router-link
+                to="/cases"
+                class="inline-flex items-center text-sm font-medium text-indigo-700 hover:text-indigo-900 underline-offset-4 hover:underline"
+              >
+                先看案例
+              </router-link>
+            </div>
+          </div>
         </div>
-        <div class="mt-5 flex flex-wrap items-center gap-3">
-          <a
-            href="https://github.com/TUARAN/blogger-alliance"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center rounded-full border border-amber-300 bg-white/90 px-4 py-2 text-sm font-semibold text-amber-800 transition-colors hover:bg-amber-50"
-          >
-            <span class="mr-2">🤝</span>
-            加入博主联盟
-          </a>
+
+        <!-- 博主/共创者 -->
+        <div class="group relative overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-white via-amber-50/40 to-orange-50/50 p-7 transition-all hover:shadow-lg hover:shadow-amber-100">
+          <div class="absolute -top-12 -right-12 h-32 w-32 rounded-full bg-amber-200/40 blur-2xl pointer-events-none"></div>
+          <div class="relative">
+            <div class="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.22em] text-amber-700">
+              <span aria-hidden="true">🛠</span>
+              For Builders
+            </div>
+            <div class="mt-2 text-xl font-semibold text-slate-900">我是博主 / AI 爱好者</div>
+            <p class="mt-3 text-sm leading-7 text-slate-600">
+              想共创内容、尝试 AI 项目、打磨开发者工具，或者用兼职方式参与真实合作。欢迎长期协作，也欢迎从一次共创开始。
+            </p>
+            <div class="mt-6 flex flex-wrap items-center gap-3">
+              <a
+                href="https://github.com/TUARAN/blogger-alliance"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-slate-800 transition-colors"
+              >
+                加入博主联盟
+                <span aria-hidden="true">→</span>
+              </a>
+              <router-link
+                to="/academy"
+                class="inline-flex items-center text-sm font-medium text-amber-700 hover:text-amber-900 underline-offset-4 hover:underline"
+              >
+                了解联盟学院
+              </router-link>
+            </div>
+          </div>
         </div>
       </div>
     </section>
@@ -258,7 +415,7 @@ const expandedBloggers = ref([])
 const bloggerStats = ref(getBloggerStats())
 
 /** 网格视图默认只展示前若干位，降低首屏以下长度与图片请求 */
-const BLOGGER_GRID_PREVIEW = 18
+const BLOGGER_GRID_PREVIEW = 16
 const bloggersGridExpanded = ref(false)
 
 const moreDataModalOpen = ref(false)

--- a/src/pages/tob/services/ai-access.vue
+++ b/src/pages/tob/services/ai-access.vue
@@ -4,8 +4,13 @@
       <header class="mb-8">
         <h1 class="text-3xl md:text-4xl font-bold text-gray-900">AI Access 推广</h1>
         <p class="mt-3 text-lg text-gray-600">
-          面向海外大模型与 AI 工具使用需求，围绕 ChatGPT、Claude 等话题持续做资讯分发、内容二创、建站承接、文档沉淀、仓库搭建和社区扩散，适合按高提成结果长期合作。
+          聚焦境外大模型与 AI SaaS（ChatGPT、Claude、Midjourney 等订阅类工具）的国内承接：以现有 AI 站点矩阵 + GitHub 仓库 SEO + 小红书 / 社群 三位一体做长期分佣联运，按高 LTV 成交结果合作。
         </p>
+        <div class="mt-3 flex flex-wrap gap-2 text-xs">
+          <span class="inline-flex items-center rounded-full bg-orange-50 border border-orange-200 px-2.5 py-1 text-orange-700">订阅类 SaaS · 高复购</span>
+          <span class="inline-flex items-center rounded-full bg-amber-50 border border-amber-200 px-2.5 py-1 text-amber-700">分佣 30%–60% / 笔</span>
+          <span class="inline-flex items-center rounded-full bg-rose-50 border border-rose-200 px-2.5 py-1 text-rose-700">建议 ≥ 3 个月协同</span>
+        </div>
       </header>
 
       <section class="bg-white/80 backdrop-blur-sm rounded-2xl border border-gray-200 shadow-sm p-6">
@@ -14,24 +19,24 @@
           <div class="rounded-xl border border-gray-200 bg-white/70 p-4">
             <div class="text-sm font-semibold text-gray-900">这项服务在做什么</div>
             <p class="mt-2 text-sm text-gray-600 leading-relaxed">
-              持续围绕大模型热点、模型使用门槛、账号获取方式、使用技巧与资讯变化发布内容，并把用户承接到站点、文档、仓库、社群或指定落地入口，形成可持续转化链路。
+              围绕大模型热点、模型对比、账号 / 订阅获取路径、Prompt 与使用技巧持续生产内容（资讯流 + 教程 + 测评），把流量沉淀到 AI 工具站点矩阵、GitHub Awesome 仓库和 AI 学习社群，形成可复用的订阅转化链路。
             </p>
           </div>
           <div class="rounded-xl border border-gray-200 bg-white/70 p-4">
-            <div class="text-sm font-semibold text-gray-900">适合谁</div>
+            <div class="text-sm font-semibold text-gray-900">适合谁（聚焦订阅类）</div>
             <ul class="mt-2 space-y-1.5 text-sm text-gray-600">
-              <li class="flex items-start"><span class="text-orange-600 mr-2">•</span><span>面向国内用户提供海外 AI 模型使用支持、账号服务或配套工具的团队</span></li>
-              <li class="flex items-start"><span class="text-orange-600 mr-2">•</span><span>希望在小红书、社区、搜索入口持续获取高意向 AI 用户</span></li>
-              <li class="flex items-start"><span class="text-orange-600 mr-2">•</span><span>接受高提成合作方式，并愿意把转化链路交给我们一起搭建的合作方</span></li>
+              <li class="flex items-start"><span class="text-orange-600 mr-2">•</span><span>境外 AI SaaS / API 服务：账号代订阅、API 中转、Prompt 平台等</span></li>
+              <li class="flex items-start"><span class="text-orange-600 mr-2">•</span><span>面向 C 端 / 创作者的 AI 工具（写作、绘画、视频、Agent）</span></li>
+              <li class="flex items-start"><span class="text-orange-600 mr-2">•</span><span>客单价 ≥ ¥20 / 月、有复购或包月订阅模型，且能给出 ≥ 30% 分佣空间</span></li>
             </ul>
           </div>
           <div class="rounded-xl border border-gray-200 bg-white/70 p-4">
-            <div class="text-sm font-semibold text-gray-900">我们能做什么</div>
+            <div class="text-sm font-semibold text-gray-900">我们的现有资产</div>
             <ul class="mt-2 space-y-1.5 text-sm text-gray-600">
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>跟踪 Twitter/X、海外 AI 社区、产品更新和热点事件</span></li>
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>做资讯整理、新闻转发、观点二创、实用教程和专题内容</span></li>
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>搭建门户站点、文档页、导航页、GitHub 仓库和专题落地页</span></li>
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>结合帖子、评论、社群和社区平台形成持续引流</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>AI 主题站点矩阵 + 长尾 SEO 入口（持续承接搜索意图）</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>GitHub Awesome / 教程类仓库（带 star 与 fork 沉淀）</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>小红书 / 公众号 / 掘金 等 AI 话题账号矩阵</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>AI 学习与体验类社群，便于二次触达与复购转化</span></li>
             </ul>
           </div>
         </div>

--- a/src/pages/tob/services/oversea-cloud.vue
+++ b/src/pages/tob/services/oversea-cloud.vue
@@ -4,8 +4,13 @@
       <header class="mb-8">
         <h1 class="text-3xl md:text-4xl font-bold text-gray-900">出海云访问 推广</h1>
         <p class="mt-3 text-lg text-gray-600">
-          面向出海团队、跨境电商、海外开发者协作等场景，围绕海外云服务、节点稳定性、客户端体验、出海办公与跨境访问等话题持续做内容分发、专题落地与社群承接，按高提成结果合作。
+          聚焦云服务、节点稳定性、客户端体验与跨境办公场景：以真实节点测速、对比测评、踩坑解读形成可信教程站，结合出海团队与跨境开发者社群承接长期分佣联运，按合规出海场景的高 LTV 成交合作。
         </p>
+        <div class="mt-3 flex flex-wrap gap-2 text-xs">
+          <span class="inline-flex items-center rounded-full bg-cyan-50 border border-cyan-200 px-2.5 py-1 text-cyan-700">出海工具 · 真实节点测速</span>
+          <span class="inline-flex items-center rounded-full bg-amber-50 border border-amber-200 px-2.5 py-1 text-amber-700">分佣 30%–60% / 笔</span>
+          <span class="inline-flex items-center rounded-full bg-blue-50 border border-blue-200 px-2.5 py-1 text-blue-700">仅合规出海 / 跨境场景</span>
+        </div>
       </header>
 
       <section class="bg-white/80 backdrop-blur-sm rounded-2xl border border-gray-200 shadow-sm p-6">
@@ -14,24 +19,24 @@
           <div class="rounded-xl border border-gray-200 bg-white/70 p-4">
             <div class="text-sm font-semibold text-gray-900">这项服务在做什么</div>
             <p class="mt-2 text-sm text-gray-600 leading-relaxed">
-              围绕出海云访问、跨境办公和海外服务的真实使用场景做内容生产，把有访问需求的用户承接到品牌方的官网、文档、教程站点、社群和导航页，形成可持续的转化链路。
+              围绕真实出海场景（团队协作、跨境电商、海外开发者远程办公）做节点实测、客户端配置教程、对比测评和踩坑解读，把有跨境访问需求的用户承接到品牌方教程站、对比导航与出海社群，形成可持续的高 LTV 转化链路。
             </p>
           </div>
           <div class="rounded-xl border border-gray-200 bg-white/70 p-4">
-            <div class="text-sm font-semibold text-gray-900">适合谁</div>
+            <div class="text-sm font-semibold text-gray-900">适合谁（聚焦出海工具）</div>
             <ul class="mt-2 space-y-1.5 text-sm text-gray-600">
-              <li class="flex items-start"><span class="text-cyan-600 mr-2">•</span><span>合规面向出海团队 / 跨境业务的云访问、加速、企业出海工具品牌</span></li>
-              <li class="flex items-start"><span class="text-cyan-600 mr-2">•</span><span>希望在小红书、技术社区、搜索入口持续获取高意向用户</span></li>
-              <li class="flex items-start"><span class="text-cyan-600 mr-2">•</span><span>接受高提成分佣，并愿意把转化链路与内容资产交给联盟一起搭建</span></li>
+              <li class="flex items-start"><span class="text-cyan-600 mr-2">•</span><span>面向出海团队的云服务 / CDN / 加速 / 跨境办公套件（合规出海场景）</span></li>
+              <li class="flex items-start"><span class="text-cyan-600 mr-2">•</span><span>面向跨境电商、海外开发者协作的 SaaS 与企业工具</span></li>
+              <li class="flex items-start"><span class="text-cyan-600 mr-2">•</span><span>愿意按高 LTV 长期合作（年付订阅 / 企业套餐），并能提供 ≥ 30% 分佣空间</span></li>
             </ul>
           </div>
           <div class="rounded-xl border border-gray-200 bg-white/70 p-4">
-            <div class="text-sm font-semibold text-gray-900">我们能做什么</div>
+            <div class="text-sm font-semibold text-gray-900">我们的现有资产</div>
             <ul class="mt-2 space-y-1.5 text-sm text-gray-600">
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>跟进出海赛道动态、产品更新、节点变化与使用场景</span></li>
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>做使用教程、对比测评、场景化案例和踩坑解读</span></li>
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>搭建专题站点、教程文档、导航页和 GitHub 资源仓库</span></li>
-              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>结合帖子、评论、社群和社区平台形成持续引流</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>出海主题教程站 + 对比导航页（围绕真实节点 / 客户端实测）</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>跨境技术社区与出海团队私域社群（B 端 / 技术受众为主）</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>掘金 / 知乎 / GitHub 等技术平台的出海话题内容矩阵</span></li>
+              <li class="flex items-start"><span class="text-gray-500 mr-2">•</span><span>持续维护的踩坑解读与真实节点测速数据库</span></li>
             </ul>
           </div>
         </div>

--- a/src/pages/tob/services/tweet.vue
+++ b/src/pages/tob/services/tweet.vue
@@ -4,8 +4,13 @@
       <header class="mb-8">
         <h1 class="text-3xl md:text-4xl font-bold text-gray-900">推文服务</h1>
         <p class="mt-3 text-gray-600">
-          面向技术受众的内容分发合作，提供从「直发」到「深度测评」的不同强度推文方案，兼顾速度、可信度与转化质量。
+          面向技术受众的内容分发合作，提供从「直发」到「深度测评」的不同强度推文方案，兼顾速度、可信度与转化质量。<strong class="text-gray-900">单次最多可调动 20 位博主</strong>在掘金 / 知乎 / 小红书 / 公众号 / X 等多平台同时分发，快速形成话题密度。
         </p>
+        <div class="mt-3 flex flex-wrap gap-2 text-xs">
+          <span class="inline-flex items-center rounded-full bg-indigo-50 border border-indigo-200 px-2.5 py-1 text-indigo-700">最多 20 位 / 单次</span>
+          <span class="inline-flex items-center rounded-full bg-emerald-50 border border-emerald-200 px-2.5 py-1 text-emerald-700">5 大平台同发</span>
+          <span class="inline-flex items-center rounded-full bg-amber-50 border border-amber-200 px-2.5 py-1 text-amber-700">直发 / 测评 / 深度测评 三档可选</span>
+        </div>
       </header>
 
       <section class="bg-white/80 backdrop-blur-sm rounded-2xl border border-gray-200 shadow-sm p-6">


### PR DESCRIPTION
## Summary

围绕"服务总览定价对比表"与"首页 Hero / 定位 / 优势"两条主线做了一轮重构，B 端品牌方决策路径更清晰，整体视觉层级一致。

### 服务总览（ServiceOverviewSection）
- 「类型」→「合作模式」语义化：单次交付 / 按效果·CPC / 月度运营 / 联运分佣
- 报价列加**起步价**与浮动依据；表头注明"报价口径混合"
- 「主要效果」→「核心指标 / 资产」，拆指标与沉淀双行
- 周期列补**最短起投周期**（单篇起 / ≥2 周 / 月度 / ≥3 个月）
- 3 行常规与 2 行专题之间加分组分隔行
- 推文行加「**最多 20 位博主 · 多平台同发**」能力副标
- 底部「想直接询价？加微信 atar24」CTA
- 移动端 < md 改卡片式堆叠，告别 8 列横滚

### 首页 Hero & 全局
- 顶导收敛：服务介绍 / 案例 / 联盟学院 / **工作台 ▾**（工作总览 / 矩阵看板 / 内部数据 / 同步工具下拉）
- Hero：「博主联盟 · 连接 AI 产品与技术影响力」渐变主标 + 4 个 feature chips + 主次 CTA + 5 色数据条
- 新增 `#positioning` 模块：
  - 左：**生态定位** 4 层 L1/L2/**L3 我们在这**/L4 可视化卡片，链接到 /ecosystem
  - 右：**4 项核心能力** — 技术内容生产力 / 开发者真实在场 / GEO 长期可见度 / 流程清晰可履约，链接到 /why-us
- 底部 CTA 拆「**For Brands / For Builders**」双卡入口（indigo 渐变 vs amber 渐变）
- `BLOGGER_GRID_PREVIEW` 18 → 16（4×4 矩阵作为核心竞争力的视觉锚点）

### 服务详情差异化
- AI Access：聚焦境外大模型 / AI SaaS 订阅类，加既有资产清单（站点矩阵 + GitHub 仓库 + 小红书账号 + AI 学习社群）
- 出海云访问：聚焦云服务 / 节点 / 跨境办公，加既有资产清单（教程站 + 跨境社群 + 技术内容矩阵 + 节点测速数据库）
- 推文页：加 20 位博主 + 多平台分发 + 三档可选 三个 hero 徽章

### 视觉与交互克制
- QrCorner 默认折叠成小药丸 + 延迟 1.8s 出现，避免首屏遮挡
- BloggerCard / BloggerControls 视觉减重（线框替代填充，icon-only 工具栏）

## Test plan
- [ ] 桌面 / 移动端 Hero 渲染正常，渐变主标 & 5 色数据条可见
- [ ] `#positioning` 锚点可点击跳转
- [ ] 服务总览表「专项介绍 / 查看案例」链接全部到位
- [ ] 移动端服务总览卡片堆叠正常
- [ ] AppNav 工作台下拉点击外部可关闭，3 个子项跳转正常
- [ ] QrCorner 首屏不立即出现，1.8s 后小药丸出现、点击展开 QR
- [ ] 底部双 CTA 链接（#service-overview / /cases / GitHub / /academy）正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)