### PR TITLE
feat(ledger): 结算字段级加密 + Git 协作权威源，台账网页改只读

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ledger:validate": "node scripts/ledger-validate.mjs",
     "ledger:sync": "node scripts/ledger-sync.mjs",
     "ledger:migrate-excel": "node scripts/migrate-excel-to-ledger.mjs",
+    "ledger:restore-aux": "node scripts/ledger-restore-aux.mjs",
     "supabase:auth-urls": "node scripts/configure-supabase-auth-urls.mjs",
     "metrics:login": "node scripts/collect-visible-metrics.mjs login",
     "metrics:collect": "node scripts/collect-visible-metrics.mjs collect"

--- a/scripts/ledger-restore-aux.mjs
+++ b/scripts/ledger-restore-aux.mjs
@@ -1,0 +1,87 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { withClient } from './lib/supabaseDb.mjs'
+
+/**
+ * 一次性回灌 promotion_reports / annual_reports。
+ *
+ * 背景：台账网页改只读后，reports/annual 不再有网页编辑器入口；deals 走
+ * data/ledger + ledger:sync，而 reports/annual 暂仍以 private/*.source.json
+ * 为本地源。本脚本读取这两个源文件，调用 replace_* RPC 全量覆盖回库。
+ *
+ * 用法：
+ *   npm run ledger:restore-aux             # 写库
+ *   npm run ledger:restore-aux -- --dry-run  # 只读源文件并统计，不连库
+ *
+ * 注：这两个源文件不含加密结算字段，无需密码短语。
+ */
+
+const SOURCES = {
+  reports: {
+    file: 'private/promotionReports.source.json',
+    rpc: 'replace_promotion_reports',
+    table: 'promotion_reports'
+  },
+  annual: {
+    file: 'private/annualReports.source.json',
+    rpc: 'replace_annual_reports',
+    table: 'annual_reports'
+  }
+}
+
+async function readRecords(relFile) {
+  const abs = path.resolve(process.cwd(), relFile)
+  let raw
+  try {
+    raw = await fs.readFile(abs, 'utf8')
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(`找不到源文件：${relFile}`)
+    }
+    throw error
+  }
+  const parsed = JSON.parse(raw)
+  const records = Array.isArray(parsed)
+    ? parsed
+    : parsed.reports || parsed.annualReports || []
+  if (!Array.isArray(records)) {
+    throw new Error(`${relFile} 解析后不是数组。`)
+  }
+  return records
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+
+  const reports = await readRecords(SOURCES.reports.file)
+  const annual = await readRecords(SOURCES.annual.file)
+
+  console.log(`读取：promotion_reports ${reports.length} 条，annual_reports ${annual.length} 条。`)
+
+  if (dryRun) {
+    console.log('[dry-run] 未写库。')
+    return
+  }
+
+  const { label } = await withClient(async (client) => {
+    const r = await client.query(
+      `select public.${SOURCES.reports.rpc}($1::jsonb) as count`,
+      [JSON.stringify(reports)]
+    )
+    const a = await client.query(
+      `select public.${SOURCES.annual.rpc}($1::jsonb) as count`,
+      [JSON.stringify(annual)]
+    )
+    console.log(`已写入 promotion_reports ${r.rows[0]?.count ?? 0} 条。`)
+    console.log(`已写入 annual_reports ${a.rows[0]?.count ?? 0} 条。`)
+    return {}
+  })
+
+  console.log(`完成（连接：${label}）。`)
+}
+
+main().catch((error) => {
+  console.error(error.message || error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## 背景
台账原权威源是 gitignore 的 private/*.source.json（不进 git、无法协作），且 commercial_deals 无结算金额字段。本 PR 把台账迁到 Git 跟踪的 data/ledger/deals/<id>.json（每合作一文件），并对结算金额做字段级加密——密文进库/进 git，明文绝不落盘到仓库，同时满足「Git 协作」与「敏感不外泄」。

## 主要改动
- 加密：src/utils/settlementCrypto.js（浏览器解密）+ scripts/lib/settlementEnvelope.mjs（Node 加密），AES-256-GCM + PBKDF2 信封，零新依赖。密码短语永不入库/入 git。
- 角色：新增 manager（普通管理员，维护台账但看不到金额）；唯一 admin(owner) 凭密码短语本地解密。改 useAuth.js、worker.js（ROLE_RANK/ASSIGNABLE_ROLES、handleDeals 仅对 admin 下发 settlement_cipher）、用户管理页、006 migration。
- 录入改 Git + 脚本：ledger:validate / ledger:encrypt / ledger:sync / ledger:migrate-excel。
- /tob/internal 改只读：移除新增/编辑/删除表单与年度编辑器，新增结算列（默认打码，owner 解锁后本地解密）。
- 修复：reports/annual 失去网页入口后，新增 ledger:restore-aux 回灌脚本（读 private/*.source.json → replace_* RPC）。
- 规范：data/ledger/README.md + schema.json；根目录 CLAUDE.md / AGENTS.md；更新 README.md。

## 验证
- npm run build 通过；ledger:validate 通过（17 条）。
- 线上数据已用本脚本恢复：deals 17 / reports 7 / annual 1。
- 所有 git 跟踪文件 settlement 均为 null，无明文金额。

## 合并后需手动执行（owner，需密码短语）
1. 从 Excel 重出明文：ledger:migrate-excel → ledger:encrypt → 删明文
2. npm run ledger:sync（填上加密结算）
3. /workspace/users 把协作者设为 manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)